### PR TITLE
fix(ci): fetch AG-UI LFS fixtures for Dojo tests

### DIFF
--- a/.github/workflows/test_e2e-dojo.yml
+++ b/.github/workflows/test_e2e-dojo.yml
@@ -187,6 +187,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ag-ui-protocol/ag-ui
+          lfs: true
           path: ag-ui
           ref: main
           persist-credentials: false


### PR DESCRIPTION
## Problem

The three LangGraph Dojo multimodal suites fail before sending the image because `ag-ui/apps/dojo/e2e/fixtures/test-image.png` is a Git LFS pointer rather than an image.

## Why

The workflow enables LFS for its CopilotKit checkout but not its separate AG-UI checkout. The fixture is stored in AG-UI through LFS.

## Fix

Set `lfs: true` on the AG-UI checkout. No test or application behavior changes.

Evidence: all three failed CI jobs report that the image is a Git LFS pointer. Locally, the Git object is a 127-byte pointer; applying LFS smudge produces a 70-byte file with a valid PNG signature. `actionlint` passes with the existing Depot runner label configured and shellcheck disabled.

This addresses a separate CI blocker seen on #7069. Full Dojo verification requires the hosted workflow; local validation covers fixture materialization and workflow syntax.
