### PR TITLE
test(mastra): keep sub-agent supervisor exposed

### DIFF
--- a/showcase/integrations/mastra/tests/vitest/route.test.ts
+++ b/showcase/integrations/mastra/tests/vitest/route.test.ts
@@ -194,7 +194,12 @@ describe("buildAgents", () => {
     const agents = buildAgents();
 
     expect(agents.subagentsSupervisorAgent).toBeDefined();
-    expect(agents.subagentsSupervisorAgent).not.toBe(agents.weatherAgent);
+    expect(mockedGetLocalAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "subagentsSupervisorAgent",
+        resourceId: "mastra-subagentsSupervisorAgent",
+      }),
+    );
   });
 
   it("throws when getLocalAgent returns null for any demo alias", async () => {

--- a/showcase/integrations/mastra/tests/vitest/route.test.ts
+++ b/showcase/integrations/mastra/tests/vitest/route.test.ts
@@ -27,6 +27,10 @@ vi.mock("@/mastra", () => ({
   mastra: { __stub: "mastra" },
 }));
 
+vi.mock("@/mastra/_header_forwarding", () => ({
+  withForwardedHeaders: (_request: unknown, fn: () => unknown) => fn(),
+}));
+
 // Stub @ag-ui/mastra with controllable implementations. Tests reassign these
 // per-case via vi.mocked(...).
 vi.mock("@ag-ui/mastra", () => {
@@ -152,6 +156,45 @@ describe("buildAgents", () => {
     ];
     expect(new Set(seen).size).toBe(seen.length);
     expect(seen.sort()).toEqual([...expected].sort());
+  });
+
+  it("keeps the subagents supervisor available as its own runtime agent", async () => {
+    mockedGetLocalAgents.mockReturnValue({
+      weatherAgent: makeAgent("weather", "mastra-weatherAgent"),
+      headlessCompleteAgent: makeAgent(
+        "headless-complete",
+        "mastra-headlessCompleteAgent",
+      ),
+      sharedStateReadWriteAgent: makeAgent(
+        "shared-state-rw",
+        "mastra-sharedStateReadWriteAgent",
+      ),
+      sharedStateStreamingAgent: makeAgent(
+        "shared-state-streaming",
+        "mastra-sharedStateStreamingAgent",
+      ),
+      genUiAgent: makeAgent("gen-ui", "mastra-genUiAgent"),
+      subagentsSupervisorAgent: makeAgent(
+        "subagents-supervisor",
+        "mastra-subagentsSupervisorAgent",
+      ),
+      interruptAgent: makeAgent("interrupt", "mastra-interruptAgent"),
+      multimodalAgent: makeAgent("multimodal", "mastra-multimodalAgent"),
+      mcpAppsAgent: makeAgent("mcp-apps", "mastra-mcpAppsAgent"),
+      byocHashbrownAgent: makeAgent(
+        "byoc-hashbrown",
+        "mastra-byocHashbrownAgent",
+      ),
+    });
+    mockedGetLocalAgent.mockImplementation(({ agentId, resourceId }) =>
+      makeAgent(agentId as string, resourceId),
+    );
+
+    const { buildAgents } = await importRoute();
+    const agents = buildAgents();
+
+    expect(agents.subagentsSupervisorAgent).toBeDefined();
+    expect(agents.subagentsSupervisorAgent).not.toBe(agents.weatherAgent);
   });
 
   it("throws when getLocalAgent returns null for any demo alias", async () => {


### PR DESCRIPTION
## What does this PR do?

Adds a regression assertion to the Mastra route tests ensuring the sub-agents supervisor remains available as a distinct runtime agent instead of being replaced by the default weather agent.

## Related PRs and Issues

- Fixes #2732

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that the supervisor agent remains available as a distinct runtime agent.
  * Added test support for configurations containing shared-state streaming, generative UI, and BYOC agents.
  * Added coverage for request handling with forwarded-header support in integration routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
