### PR TITLE
fix(web-inspector): unify Intelligence onboarding states

### DIFF
--- a/packages/web-inspector/dev/threads-state-lab.spec.ts
+++ b/packages/web-inspector/dev/threads-state-lab.spec.ts
@@ -395,26 +395,12 @@ function expectedOverviewCopy(
   scenario: ThreadsStateScenario,
 ): Readonly<{ heading: string; description: string }> | null {
   if (scenario.data === "error") return null;
-  if (scenario.runtimeInfo.licenseStatus === "none") {
+  if (scenario.capability !== "enabled") {
     return {
       heading:
         "Production-grade chat threads without the complexity. Self hostable.",
       description:
         "Chat threads that go beyond text with generative UI and multimodal inputs, built to replay missed events and stay in sync across tabs, sessions, and devices.",
-    };
-  }
-  if (scenario.runtimeInfo.licenseStatus === "expired") {
-    return {
-      heading: "Renew Intelligence to inspect Threads.",
-      description:
-        "Your Intelligence access has expired. Renew it to inspect saved thread history.",
-    };
-  }
-  if (scenario.capability !== "enabled") {
-    return {
-      heading: "Finish setting up Rich Threads",
-      description:
-        "Copy this prompt into your coding agent to finish the setup.",
     };
   }
   if (scenario.data === "existing") return null;

--- a/packages/web-inspector/src/__tests__/inspector-metadata.spec.ts
+++ b/packages/web-inspector/src/__tests__/inspector-metadata.spec.ts
@@ -294,22 +294,17 @@ test.each([
   },
 );
 
+const LOCKED_THREADS_HEADING =
+  "Production-grade chat threads without the complexity. Self hostable.";
+
 test.each([
-  ["valid", "manage_plan", "Finish setting up Rich Threads"],
-  [
-    "none",
-    "enable_intelligence",
-    "Production-grade chat threads without the complexity. Self hostable.",
-  ],
-  ["expired", "renew", "Renew Intelligence to inspect Threads."],
-  [
-    "unknown",
-    "manage_plan",
-    "Production-grade chat threads without the complexity. Self hostable.",
-  ],
+  ["valid", "manage_plan"],
+  ["none", "enable_intelligence"],
+  ["expired", "renew"],
+  ["unknown", "manage_plan"],
 ] as const)(
-  "locked Threads use %s license copy and the unified actions",
-  async (licenseState, actionKind, heading) => {
+  "locked Threads ignore %s license metadata and use the unified actions",
+  async (licenseState, actionKind) => {
     const context = await setup({
       metadata: fullMetadata(licenseState, actionKind),
       runtimeLicense: licenseState,
@@ -326,7 +321,7 @@ test.each([
       const talk = root.querySelector<HTMLAnchorElement>(
         '[data-inspector-locked-feature-talk="threads"]',
       );
-      expect(root.textContent).toContain(heading);
+      expect(root.textContent).toContain(LOCKED_THREADS_HEADING);
       expect(action).toBeNull();
       expect(talk?.textContent?.trim()).toBe("Talk to an Engineer");
       expect(
@@ -442,7 +437,7 @@ test("known license disagreement uses Runtime copy and hides the metadata action
 
     const root = context.inspector.shadowRoot!;
     expect(root.textContent).toContain(
-      "Renew Intelligence to inspect Threads.",
+      "Production-grade chat threads without the complexity. Self hostable.",
     );
     expect(
       root.querySelector('[data-inspector-action-placement="locked"]'),

--- a/packages/web-inspector/src/__tests__/threads-states.spec.ts
+++ b/packages/web-inspector/src/__tests__/threads-states.spec.ts
@@ -1094,8 +1094,10 @@ const lockedActionCases: ReadonlyArray<LockedActionCase> = [
     runtimeLicense: "valid",
     actionKind: "manage_plan",
     actionUrl: "https://cloud.copilotkit.ai/actions/manage",
-    heading: "Finish setting up Rich Threads",
-    description: "Copy this prompt into your coding agent to finish the setup.",
+    heading:
+      "Production-grade chat threads without the complexity. Self hostable.",
+    description:
+      "Chat threads that go beyond text with generative UI and multimodal inputs, built to replay missed events and stay in sync across tabs, sessions, and devices.",
   },
   {
     name: "none enable action",
@@ -1114,7 +1116,8 @@ const lockedActionCases: ReadonlyArray<LockedActionCase> = [
     runtimeLicense: "expired",
     actionKind: "renew",
     actionUrl: "https://cloud.copilotkit.ai/actions/renew",
-    heading: "Renew Intelligence to inspect Threads.",
+    heading:
+      "Production-grade chat threads without the complexity. Self hostable.",
   },
   {
     name: "expired manage action",
@@ -1122,7 +1125,8 @@ const lockedActionCases: ReadonlyArray<LockedActionCase> = [
     runtimeLicense: "expired",
     actionKind: "manage_plan",
     actionUrl: "https://cloud.copilotkit.ai/actions/manage-expired",
-    heading: "Renew Intelligence to inspect Threads.",
+    heading:
+      "Production-grade chat threads without the complexity. Self hostable.",
   },
   {
     name: "unknown action",
@@ -1155,7 +1159,8 @@ const lockedActionCases: ReadonlyArray<LockedActionCase> = [
     runtimeLicense: "expired",
     actionKind: "enable_intelligence",
     actionUrl: "https://cloud.copilotkit.ai/actions/conflict",
-    heading: "Renew Intelligence to inspect Threads.",
+    heading:
+      "Production-grade chat threads without the complexity. Self hostable.",
   },
 ];
 
@@ -1380,7 +1385,9 @@ test.each(footerCases)(
       );
       if (state === "locked") {
         expect(footers).toHaveLength(0);
-        expect(root.textContent).toContain("Finish setting up Rich Threads");
+        expect(root.textContent).toContain(
+          "Production-grade chat threads without the complexity. Self hostable.",
+        );
         return;
       }
       const footer = footers[0];

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -2258,7 +2258,8 @@ test.each([
         entitlementSource: "clerk_subscription",
       },
     },
-    lockedHeading: "Renew Intelligence to inspect Threads.",
+    lockedHeading:
+      "Production-grade chat threads without the complexity. Self hostable.",
   },
   {
     diagnostic: "expired self-hosted entitlement",
@@ -2273,7 +2274,8 @@ test.each([
         traceId: "trace-expired",
       },
     },
-    lockedHeading: "Finish setting up Rich Threads",
+    lockedHeading:
+      "Production-grade chat threads without the complexity. Self hostable.",
   },
   {
     diagnostic: "misconfigured self-hosted entitlement",
@@ -2286,7 +2288,8 @@ test.each([
         retryable: false,
       },
     },
-    lockedHeading: "Finish setting up Rich Threads",
+    lockedHeading:
+      "Production-grade chat threads without the complexity. Self hostable.",
   },
   {
     diagnostic: "unavailable managed entitlement",
@@ -2299,7 +2302,8 @@ test.each([
         retryable: true,
       },
     },
-    lockedHeading: "Finish setting up Rich Threads",
+    lockedHeading:
+      "Production-grade chat threads without the complexity. Self hostable.",
   },
   {
     diagnostic: "SDK fail-soft entitlement lookup",
@@ -2312,7 +2316,8 @@ test.each([
         retryable: true,
       },
     },
-    lockedHeading: "Finish setting up Rich Threads",
+    lockedHeading:
+      "Production-grade chat threads without the complexity. Self hostable.",
   },
 ] as const)(
   "keeps the unified locked splash for $diagnostic",
@@ -2359,7 +2364,7 @@ test("keeps the unified locked splash for an expired legacy license", async () =
     );
     expect(diagnostics).toHaveLength(0);
     expect(inspector.shadowRoot?.textContent ?? "").toContain(
-      "Renew Intelligence to inspect Threads.",
+      "Production-grade chat threads without the complexity. Self hostable.",
     );
   } finally {
     fixture.teardown();
@@ -2432,12 +2437,14 @@ test.each([
       },
       licenseStatus: "expired",
     },
-    lockedHeading: "Renew Intelligence to inspect Threads.",
+    lockedHeading:
+      "Production-grade chat threads without the complexity. Self hostable.",
   },
   {
     diagnostic: "legacy valid license",
     diagnostics: { licenseStatus: "valid" },
-    lockedHeading: "Finish setting up Rich Threads",
+    lockedHeading:
+      "Production-grade chat threads without the complexity. Self hostable.",
   },
 ] as const)(
   "keeps Threads unavailable for $diagnostic when the Runtime omits list capability",

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -1024,6 +1024,13 @@ const AGENT_EVENT_TYPES: readonly InspectorAgentEventType[] = [
   "ACTIVITY_DELTA",
 ] as const;
 
+const THREADS_LOCKED_COPY = {
+  heading:
+    "Production-grade chat threads without the complexity. Self hostable.",
+  description:
+    "Chat threads that go beyond text with generative UI and multimodal inputs, built to replay missed events and stay in sync across tabs, sessions, and devices.",
+} as const;
+
 type SanitizedValue =
   | string
   | number
@@ -18363,34 +18370,6 @@ export class WebInspectorElement extends LitElement {
     `;
   }
 
-  private getThreadsLockedCopy(): {
-    heading: string;
-    description: string;
-  } {
-    switch (this.inspectorMetadataProjection.licenseState) {
-      case "valid":
-        return {
-          heading: "Finish setting up Rich Threads",
-          description:
-            "Copy this prompt into your coding agent to finish the setup.",
-        };
-      case "none":
-      case "unknown":
-        return {
-          heading:
-            "Production-grade chat threads without the complexity. Self hostable.",
-          description:
-            "Chat threads that go beyond text with generative UI and multimodal inputs, built to replay missed events and stay in sync across tabs, sessions, and devices.",
-        };
-      case "expired":
-        return {
-          heading: "Renew Intelligence to inspect Threads.",
-          description:
-            "Your Intelligence access has expired. Renew it to inspect saved thread history.",
-        };
-    }
-  }
-
   /**
    * Renders the realtime-connection indicator in the memory-store header.
    * Only `"connected"` shows the live (green-dot) state; `"connecting"` shows a
@@ -18821,12 +18800,11 @@ export class WebInspectorElement extends LitElement {
     const locked = !this.areThreadEndpointsAvailable();
     if (locked) {
       this.trackThreadsViewStateOnce("locked");
-      const lockedCopy = this.getThreadsLockedCopy();
       return this.renderLockedFeatureOverview({
         serviceId: "threads",
         featureName: "Rich Threads",
-        heading: lockedCopy.heading,
-        description: lockedCopy.description,
+        heading: THREADS_LOCKED_COPY.heading,
+        description: THREADS_LOCKED_COPY.description,
         videoUrl: THREADS_LOCKED_VIDEO_URL,
         videoTitle: "Rich Threads overview",
         outlineItems: THREADS_LOCKED_FEATURE_OUTLINE,

--- a/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
@@ -220,10 +220,10 @@ host/port.
 
 ## Enable Rich Threads routes
 
-If the Inspector says **Finish setting up Rich Threads**, your Intelligence
-license is active but the client did not find the features used to list and
-inspect saved Threads. Complete these steps so Runtime info advertises those
-features and the Inspector can load saved history.
+If the Inspector shows the Rich Threads setup view, the client did not find the
+features used to list and inspect saved Threads. This view is based on Runtime
+Threads capability, not license metadata. Complete these steps so Runtime info
+advertises those features and the Inspector can load saved history.
 
 <RichThreadsSetupPrompt />
 

--- a/showcase/shell-docs/src/content/docs/inspector.mdx
+++ b/showcase/shell-docs/src/content/docs/inspector.mdx
@@ -178,25 +178,13 @@ then return to Inspector to follow setup through the first eligible Thread. The
 [Intelligence quickstart](/intelligence/quickstart) explains the project,
 credentials, and Runtime routes that prompt configures.
 
-If Threads remains locked, use the action Inspector presents for the Runtime's
-current state:
-
-| State       | Next step Inspector can offer                                                    |
-| ----------- | -------------------------------------------------------------------------------- |
-| Active      | **Finish setting up Rich Threads**, a repair prompt, and the Runtime route guide |
-| Not enabled | **Enable Intelligence** when the Runtime supplies a trusted action               |
-| Expired     | **Renew** or **Manage Your Plan** when the Runtime supplies a trusted action     |
-| Unknown     | An unavailable message without an action                                         |
-
-For an active license with incomplete routes, use the Runtime route guide.
+If Threads remains locked, Inspector shows one Rich Threads setup view with
+**Copy setup prompt** and **Talk to an Engineer**. The view is based on Runtime
+Threads capability rather than license metadata. To configure incomplete
+routes, use the Runtime route guide.
 [Enable Rich Threads routes](/backend/runtime-endpoints#enable-rich-threads-routes)
 explains how to configure application-user identity, mount every required HTTP
 method, and verify the capability response.
-
-Inspector opens only action URLs supplied by the Runtime. It does not construct
-a project URL or use a fixed signup fallback. If metadata and Runtime license
-states conflict, Runtime status controls the message and the incompatible
-action is hidden.
 
 ## Review what Learning found
 
@@ -265,6 +253,11 @@ An Intelligence-backed Runtime can send trusted organization, project, plan,
 Thread usage, retention, and action metadata. Home shows valid project context;
 the Threads footer shows valid usage and relevant actions. Missing identity data
 does not hide valid usage, and missing usage does not hide a valid action.
+
+Inspector opens only action URLs supplied by the Runtime. It never constructs a
+project URL or uses a fixed signup fallback. If metadata and Runtime license
+states conflict, Runtime status wins and Inspector hides the incompatible
+action.
 
 | Usage state                 | What Inspector shows                                     |
 | --------------------------- | -------------------------------------------------------- |

--- a/showcase/shell-docs/src/content/docs/troubleshooting/event-inspector.mdx
+++ b/showcase/shell-docs/src/content/docs/troubleshooting/event-inspector.mdx
@@ -12,10 +12,10 @@ Use it when:
 - You need to inspect tool call arguments or state deltas for a specific interaction
 
 <Callout type="info">
-  The in-app Inspector handles a locked Threads tab from the Runtime's current
-  license state. It can show **Enable Intelligence**, **Renew**, or **Manage
-  plan** only when the Runtime supplies a matching trusted action URL. See
-  [Inspector](/inspector) for the state matrix.
+  The in-app Inspector locks the Threads tab when the Runtime does not advertise
+  the Threads list capability, regardless of license metadata. The locked view
+  offers **Copy setup prompt** and **Talk to an Engineer**. See
+  [Inspector](/inspector#enable-or-repair-intelligence) for the setup flow.
 </Callout>
 
 ## Prerequisites

--- a/showcase/shell-docs/src/content/snippets/shared/intelligence/inspector.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/intelligence/inspector.mdx
@@ -108,17 +108,9 @@ If you are building the Thread picker and conversation surface yourself, see
 If Intelligence is not connected, open **Home** and choose **Copy setup prompt**.
 The [Intelligence quickstart](/intelligence/quickstart) explains the project,
 credentials, and Runtime routes that prompt configures. If Threads remains
-locked after setup, follow the action shown for the Runtime's current state:
-
-| State       | Next step Inspector can offer                                                    |
-| ----------- | -------------------------------------------------------------------------------- |
-| Active      | **Finish setting up Rich Threads**, a repair prompt, and the Runtime route guide |
-| Not enabled | **Enable Intelligence** when the Runtime supplies a trusted action               |
-| Expired     | **Renew** or **Manage Your Plan** when the Runtime supplies a trusted action     |
-| Unknown     | An unavailable message without an action                                         |
-
-Inspector opens only trusted URLs supplied by the Runtime. It does not build a
-URL from project details or use a fixed signup fallback.
+locked after setup, Inspector shows one Rich Threads setup view with **Copy
+setup prompt** and **Talk to an Engineer**. The view is based on Runtime Threads
+capability rather than license metadata.
 
 `NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY` is a browser-visible publishable key. It is
 different from the server-side `CPK_INTELLIGENCE_API_KEY` that
@@ -174,6 +166,11 @@ period ends.
 An Intelligence-backed Runtime can supply trusted organization, project, plan,
 Thread usage, retention, and action metadata. Home shows valid project context;
 the Threads footer shows valid usage and relevant actions.
+
+Inspector opens only action URLs supplied by the Runtime. It never constructs a
+project URL or uses a fixed signup fallback. If metadata and Runtime license
+states conflict, Runtime status wins and Inspector hides the incompatible
+action.
 
 Finite plans show `used / limit Threads` and a progress bar. Unlimited plans
 show the used count without a bar. **Limit unavailable** means the Runtime sent


### PR DESCRIPTION
## Problem

The Inspector locked Threads state varied by license metadata even though the real availability gate is whether Runtime exposes the Threads list endpoint. That let users with Threads unavailable land in different legacy onboarding states.

## Why

License state and Threads capability are separate signals. Keying the pane on license metadata made Threads unavailable diverge from the license-disabled setup view, even though neither state can list saved Threads.

## Fix

- Gate the locked setup view on Runtime Threads capability.
- Use the intended Rich Threads product header, Copy setup prompt, engineer CTA, and video for every locked state.
- Keep the existing enabled-but-empty Threads preview when the list endpoint is available.
- Update Inspector docs to describe the capability-based state instead of removed license-specific variants.
- Simplify the static locked copy and regression coverage.
- Squash the PR into one semantic commit.

The earlier copied-prompt/intent commit was intentionally dropped during rebase because #7030 landed that work on main.

Validation:

- Inspector: 696 tests passed, 0 skipped.
- Inspector typecheck passed.
- Shell-docs typecheck passed.
- Shell-docs production build passed, including 227 static pages.
- Standalone `pro-disabled-zero` visual check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Unified the locked Threads view around Rich Threads setup guidance.
  * Added **Copy setup prompt** and **Talk to an Engineer** actions.
  * Threads availability is now determined by Runtime capability rather than license metadata.
  * Empty Threads views no longer display local example threads or example tours.

* **Documentation**
  * Updated setup and troubleshooting guidance to describe the capability-based Threads experience.
  * Clarified that Inspector uses action links supplied by Runtime and directs incomplete configurations to the Runtime route guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->