### PR TITLE
fix(runtime): await durable Intelligence stop completion

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -142,3 +142,25 @@ Or use the `DO_NOT_TRACK` standard:
 ```bash
 export DO_NOT_TRACK=1
 ```
+
+## Stopping Intelligence runs
+
+Await Stop before sending another message on the same thread. With
+`IntelligenceAgentRunner`, `stopped: true` means the gateway acknowledged the
+run's terminal events and the runtime completed local cleanup. The gateway
+releases only the lock owned by that run.
+
+Stop requests agent cancellation and excludes late agent events from thread
+history. Agents that support `detachActiveRun()` also detach their local
+subscription. Older agents remain supported. An adapter must honor cancellation
+to stop external work; Stop cannot undo tool calls that already took effect.
+
+The HTTP request and response formats are unchanged. Empty-body Stop requests
+still stop the current run. Direct runner callers can pass the existing optional
+`runId` to stop only that run. A missing, mismatched, or already-requested Stop
+returns `false`. Failed terminal delivery rejects Stop; the HTTP handler returns
+its existing error response instead of reporting success. The wait is bounded by
+the existing 60-second durability window.
+
+No Intelligence upgrade is required. The runtime uses the existing terminal
+events and supports both single-event and batched gateway acknowledgments.

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -2061,7 +2061,9 @@ describe("IntelligenceAgentRunner", () => {
         false,
       );
       expect(agent.aborted).toBe(false);
-      expect(await runner.stop({ threadId, runId: "r-current" })).toBe(true);
+      const stopping = runner.stop({ threadId, runId: "r-current" });
+      mockChannels[0].triggerJoin("ok");
+      expect(await stopping).toBe(true);
       expect(agent.aborted).toBe(true);
       sub.unsubscribe();
     });
@@ -2072,7 +2074,9 @@ describe("IntelligenceAgentRunner", () => {
       const agent = new MockAgent();
       const sub = runner.run({ threadId, agent, input }).subscribe();
 
-      const result = await runner.stop({ threadId });
+      const stopping = runner.stop({ threadId });
+      mockChannels[0].triggerJoin("ok");
+      const result = await stopping;
 
       expect(result).toBe(true);
       expect(agent.aborted).toBe(true);
@@ -2093,8 +2097,10 @@ describe("IntelligenceAgentRunner", () => {
       const agent = new MockAgent();
       const sub = runner.run({ threadId, agent, input }).subscribe();
 
-      expect(await runner.stop({ threadId })).toBe(true);
+      const stopping = runner.stop({ threadId });
       expect(await runner.stop({ threadId })).toBe(false);
+      mockChannels[0].triggerJoin("ok");
+      expect(await stopping).toBe(true);
       sub.unsubscribe();
     });
   });

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-stop-completion.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-stop-completion.test.ts
@@ -1,8 +1,7 @@
 import { AbstractAgent, EventType } from "@ag-ui/client";
 import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
 import { Observable, Subject } from "rxjs";
-import { WebSocketServer } from "ws";
-import type { WebSocket } from "ws";
+import { WebSocket, WebSocketServer } from "ws";
 import { expect, test, vi } from "vitest";
 import { IntelligenceAgentRunner } from "../intelligence";
 import { CopilotRuntime } from "../../core/runtime";
@@ -48,6 +47,10 @@ function reply(
 
 /** Exercises the real Phoenix client against a controllable gateway transport. */
 async function setup(batch = false) {
+  // Node 20 does not expose a global WebSocket. Keep Node 22+ on its native
+  // transport and supply the same protocol transport for the older CI lane.
+  const needsWebSocket = typeof globalThis.WebSocket === "undefined";
+  if (needsWebSocket) vi.stubGlobal("WebSocket", WebSocket);
   const server = new WebSocketServer({ port: 0 });
   await new Promise<void>((resolve) => server.once("listening", resolve));
   const address = server.address();
@@ -139,6 +142,7 @@ async function setup(batch = false) {
     await new Promise<void>((resolve, reject) =>
       server.close((error) => (error ? reject(error) : resolve())),
     );
+    if (needsWebSocket) vi.unstubAllGlobals();
   }
 
   return {

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-stop-completion.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-stop-completion.test.ts
@@ -1,0 +1,474 @@
+import { AbstractAgent, EventType } from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import { Observable, Subject } from "rxjs";
+import { WebSocketServer } from "ws";
+import type { WebSocket } from "ws";
+import { expect, test, vi } from "vitest";
+import { IntelligenceAgentRunner } from "../intelligence";
+import { CopilotRuntime } from "../../core/runtime";
+import { createCopilotRuntimeHandler } from "../../core/fetch-handler";
+
+type Frame = [string | null, string, string, string, Record<string, unknown>];
+
+/** Keeps producing until the test ends it, like an adapter that ignores abort. */
+class ControlledAgent extends AbstractAgent {
+  readonly output = new Subject<BaseEvent>();
+  readonly abortRun = vi.fn();
+  runCount = 0;
+
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    this.runCount++;
+    return new Observable((subscriber) => {
+      subscriber.next({
+        type: EventType.RUN_STARTED,
+        threadId: input.threadId,
+        runId: input.runId,
+      });
+      return this.output.subscribe(subscriber);
+    });
+  }
+}
+
+/** Acknowledges a Phoenix request using the same reference and topic. */
+function reply(
+  socket: WebSocket,
+  frame: Frame,
+  response: Record<string, unknown> = {},
+) {
+  socket.send(
+    JSON.stringify([
+      frame[0],
+      frame[1],
+      frame[2],
+      "phx_reply",
+      { status: "ok", response },
+    ]),
+  );
+}
+
+/** Exercises the real Phoenix client against a controllable gateway transport. */
+async function setup(batch = false) {
+  const server = new WebSocketServer({ port: 0 });
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const address = server.address();
+  if (typeof address !== "object" || address === null)
+    throw new Error("Missing test server address");
+  const events: BaseEvent[] = [];
+  const pending: Array<{
+    socket: WebSocket;
+    frame: Frame;
+    events: BaseEvent[];
+  }> = [];
+  const locks = new Map<string, string>();
+  const errors: unknown[] = [];
+  const subscriptions: Array<{ unsubscribe(): void }> = [];
+  const agents: ControlledAgent[] = [];
+  const runner = new IntelligenceAgentRunner({
+    url: `ws://127.0.0.1:${address.port}/runner`,
+  });
+
+  server.on("connection", (socket) => {
+    socket.on("message", (data) => {
+      const frame: Frame = JSON.parse(data.toString());
+      if (frame[3] === "phx_join") {
+        reply(
+          socket,
+          frame,
+          batch ? { capabilities: ["runner_event_batch_v1"] } : {},
+        );
+      } else if (frame[3] === "event" || frame[3] === "events") {
+        const received = (
+          frame[3] === "events" ? frame[4].events : [frame[4]]
+        ) as BaseEvent[];
+        pending.push({ socket, frame, events: received });
+      } else {
+        reply(socket, frame);
+      }
+    });
+  });
+
+  /** Models atomic terminal acceptance: only the exact run can release its lock. */
+  function acceptPending() {
+    for (const item of pending.splice(0)) {
+      for (const event of item.events) {
+        events.push(event);
+        if (
+          event.type === EventType.RUN_FINISHED ||
+          event.type === EventType.RUN_ERROR
+        ) {
+          const owner = event as BaseEvent & {
+            threadId: string;
+            runId: string;
+          };
+          if (locks.get(owner.threadId) === owner.runId)
+            locks.delete(owner.threadId);
+        }
+      }
+      reply(item.socket, item.frame);
+    }
+  }
+
+  /** Starts a run only when the modeled hosted lock is available. */
+  function start(runId = "run-1") {
+    if (locks.has("thread-1")) throw new Error("THREAD_LOCK_FAILED");
+    const agent = new ControlledAgent();
+    agents.push(agent);
+    locks.set("thread-1", runId);
+    const input: RunAgentInput = {
+      threadId: "thread-1",
+      runId,
+      messages: [],
+      tools: [],
+      context: [],
+      state: {},
+      forwardedProps: {},
+    };
+    subscriptions.push(
+      runner
+        .run({ threadId: input.threadId, agent, input })
+        .subscribe({ error: (error) => errors.push(error) }),
+    );
+    return agent;
+  }
+
+  /** Closes test-owned streams, sockets, timers, and server listeners. */
+  async function teardown() {
+    subscriptions.forEach((subscription) => subscription.unsubscribe());
+    agents.forEach((agent) => agent.output.complete());
+    server.clients.forEach((socket) => socket.terminate());
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+
+  return {
+    runner,
+    start,
+    pending,
+    events,
+    locks,
+    errors,
+    acceptPending,
+    teardown,
+  };
+}
+
+for (const batch of [false, true]) {
+  test(`Stop waits for terminal acceptance and permits immediate resend (${batch ? "batch" : "legacy"})`, async () => {
+    const fixture = await setup(batch);
+    try {
+      const agent = fixture.start();
+      await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+      fixture.acceptPending();
+      await vi.waitFor(() => expect(agent.isRunning).toBe(true));
+      let stopResolved = false;
+
+      const stopping = fixture.runner
+        .stop({ threadId: "thread-1" })
+        .then((result) => {
+          stopResolved = true;
+          return result;
+        });
+      await vi.waitFor(() =>
+        expect(
+          fixture.pending.some((item) =>
+            item.events.some((event) => event.type === EventType.RUN_FINISHED),
+          ),
+        ).toBe(true),
+      );
+
+      expect(stopResolved).toBe(false);
+      expect(fixture.locks.get("thread-1")).toBe("run-1");
+      expect(agent.abortRun).toHaveBeenCalledOnce();
+      fixture.acceptPending();
+      expect(await stopping).toBe(true);
+      expect(await fixture.runner.isRunning({ threadId: "thread-1" })).toBe(
+        false,
+      );
+      expect(fixture.locks.has("thread-1")).toBe(false);
+      expect(() => fixture.start("run-2")).not.toThrow();
+      expect(fixture.errors).toEqual([]);
+    } finally {
+      await fixture.teardown();
+    }
+  });
+}
+
+test("Stop detaches the local AG-UI subscription when abort does nothing", async () => {
+  const fixture = await setup();
+  try {
+    const agent = fixture.start();
+    await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+    fixture.acceptPending();
+    expect(agent.output.observed).toBe(true);
+
+    const stopping = fixture.runner
+      .stop({ threadId: "thread-1" })
+      .catch((error) => error);
+    await vi.waitFor(() => expect(agent.output.observed).toBe(false));
+    await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+    fixture.acceptPending();
+
+    expect(await stopping).toBe(true);
+  } finally {
+    await fixture.teardown();
+  }
+});
+
+for (const abortThrows of [false, true]) {
+  test(`Stop fences late events from older agents without detachActiveRun (abort throws: ${abortThrows})`, async () => {
+    const fixture = await setup();
+    try {
+      const agent = fixture.start();
+      Object.defineProperty(agent, "detachActiveRun", { value: undefined });
+      if (abortThrows)
+        agent.abortRun.mockImplementation(() => {
+          throw new Error("Adapter cannot abort");
+        });
+      await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+      fixture.acceptPending();
+
+      const stopping = fixture.runner
+        .stop({ threadId: "thread-1", runId: "run-1" })
+        .catch((error) => error);
+      agent.output.next({
+        type: EventType.CUSTOM,
+        name: "late",
+        value: "discard",
+      });
+      await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+      fixture.acceptPending();
+      expect(await stopping).toBe(true);
+      const replacement = fixture.start("run-2");
+      await vi.waitFor(() => expect(replacement.runCount).toBe(1));
+      fixture.acceptPending();
+      agent.output.next({
+        type: EventType.CUSTOM,
+        name: "late",
+        value: "discard again",
+      });
+      agent.output.error(new Error("Late producer rejection"));
+
+      expect(
+        await fixture.runner.stop({ threadId: "thread-1", runId: "run-1" }),
+      ).toBe(false);
+      expect(replacement.abortRun).not.toHaveBeenCalled();
+      expect(fixture.locks.get("thread-1")).toBe("run-2");
+      expect(fixture.events.map((event) => event.type)).not.toContain(
+        EventType.CUSTOM,
+      );
+      expect(
+        fixture.events.filter((event) => event.type === EventType.RUN_FINISHED),
+      ).toHaveLength(1);
+      expect(fixture.errors).toEqual([]);
+    } finally {
+      await fixture.teardown();
+    }
+  });
+}
+
+test("Stop closes partial text and tool calls before its single terminal event", async () => {
+  const fixture = await setup(true);
+  try {
+    const agent = fixture.start();
+    await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+    fixture.acceptPending();
+    agent.output.next({
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: "message-1",
+      role: "assistant",
+    });
+    agent.output.next({
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: "message-1",
+      delta: "partial",
+    });
+    agent.output.next({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tool-1",
+      toolCallName: "lookup",
+    });
+    agent.output.next({
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: "tool-1",
+      delta: "{}",
+    });
+    await vi.waitFor(() =>
+      expect(
+        fixture.pending
+          .flatMap((item) => item.events)
+          .some((event) => event.type === EventType.TOOL_CALL_ARGS),
+      ).toBe(true),
+    );
+    fixture.acceptPending();
+
+    const stopping = fixture.runner
+      .stop({ threadId: "thread-1" })
+      .catch((error) => error);
+    expect(await fixture.runner.stop({ threadId: "thread-1" })).toBe(false);
+    await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+    fixture.acceptPending();
+
+    expect(await stopping).toBe(true);
+    expect(fixture.events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.TEXT_MESSAGE_START,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.TOOL_CALL_START,
+      EventType.TOOL_CALL_ARGS,
+      EventType.TEXT_MESSAGE_END,
+      EventType.TOOL_CALL_END,
+      EventType.TOOL_CALL_RESULT,
+      EventType.RUN_FINISHED,
+    ]);
+    expect(fixture.events.at(-1)).toMatchObject({
+      threadId: "thread-1",
+      runId: "run-1",
+    });
+  } finally {
+    await fixture.teardown();
+  }
+});
+
+test("Stop before channel join never starts the agent and still delivers a terminal", async () => {
+  const fixture = await setup();
+  try {
+    const agent = fixture.start();
+
+    const stopping = fixture.runner
+      .stop({ threadId: "thread-1" })
+      .catch((error) => error);
+    await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+    fixture.acceptPending();
+    await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+    fixture.acceptPending();
+
+    expect(await stopping).toBe(true);
+    expect(agent.runCount).toBe(0);
+    expect(fixture.events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_FINISHED,
+    ]);
+  } finally {
+    await fixture.teardown();
+  }
+});
+
+test("Stop does not report success if terminal delivery is permanently rejected", async () => {
+  const fixture = await setup();
+  try {
+    fixture.start();
+    await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+    fixture.acceptPending();
+
+    const stopping = fixture.runner
+      .stop({ threadId: "thread-1" })
+      .catch((error) => error);
+    await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+    const item = fixture.pending.shift();
+    if (!item) throw new Error("Missing terminal request");
+    item.socket.send(
+      JSON.stringify([
+        item.frame[0],
+        item.frame[1],
+        item.frame[2],
+        "phx_reply",
+        {
+          status: "error",
+          response: { reason: "active_lock_mismatch", retryable: false },
+        },
+      ]),
+    );
+
+    expect(await stopping).toBeInstanceOf(Error);
+    expect(fixture.locks.get("thread-1")).toBe("run-1");
+    expect(fixture.errors).toHaveLength(1);
+    expect(fixture.events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+    ]);
+  } finally {
+    await fixture.teardown();
+  }
+});
+
+test("Stop rejects after the durability deadline instead of acknowledging an unreleased lock", async () => {
+  const fixture = await setup();
+  try {
+    fixture.start();
+    await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+    fixture.acceptPending();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+
+    const stopping = fixture.runner
+      .stop({ threadId: "thread-1" })
+      .catch((error) => error);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(await stopping).toBeInstanceOf(Error);
+    expect(fixture.locks.get("thread-1")).toBe("run-1");
+    expect(await fixture.runner.isRunning({ threadId: "thread-1" })).toBe(
+      false,
+    );
+    expect(fixture.errors).toHaveLength(1);
+  } finally {
+    vi.useRealTimers();
+    await fixture.teardown();
+  }
+});
+
+for (const mode of ["multi-route", "single-route"] as const) {
+  test(`The ${mode} Stop endpoint preserves its response and waits for lock release`, async () => {
+    const fixture = await setup();
+    try {
+      const agent = fixture.start();
+      const runtime = new CopilotRuntime({
+        agents: { test: agent },
+        runner: fixture.runner,
+      });
+      const handler = createCopilotRuntimeHandler({
+        runtime,
+        mode,
+        activateChannels: false,
+      });
+      await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+      fixture.acceptPending();
+      let responded = false;
+      const request =
+        mode === "multi-route"
+          ? new Request("http://runtime/agent/test/stop/thread-1", {
+              method: "POST",
+            })
+          : new Request("http://runtime", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                method: "agent/stop",
+                params: { agentId: "test", threadId: "thread-1" },
+              }),
+            });
+
+      const stopping = handler(request).then((response) => {
+        responded = true;
+        return response;
+      });
+      await vi.waitFor(() => expect(fixture.pending.length).toBeGreaterThan(0));
+      expect(responded).toBe(false);
+      fixture.acceptPending();
+      const response = await stopping;
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        stopped: true,
+        interrupt: {
+          type: EventType.RUN_ERROR,
+          message: "Run stopped by user",
+          code: "STOPPED",
+        },
+      });
+      expect(fixture.locks.has("thread-1")).toBe(false);
+      expect(() => fixture.start("run-2")).not.toThrow();
+    } finally {
+      await fixture.teardown();
+    }
+  });
+}

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -12,6 +12,7 @@ import {
   finalizeRunEvents,
   AG_UI_CHANNEL_EVENT,
   phoenixExponentialBackoff,
+  logger,
 } from "@copilotkit/shared";
 import type { Channel } from "phoenix";
 import { Socket } from "phoenix";
@@ -47,6 +48,11 @@ interface ThreadState {
   hasJoined: boolean;
   supportsRunnerEventBatch: boolean;
   producerFinished: boolean;
+  cancellation: Promise<void>;
+  cancelRun: () => void;
+  completion: Promise<boolean>;
+  resolveCompletion: (completed: boolean) => void;
+  stopTimer: ReturnType<typeof setTimeout> | null;
   pendingEvents: Map<
     string,
     { payload: Record<string, unknown>; queuedAt: number }
@@ -235,6 +241,14 @@ export class IntelligenceAgentRunner extends AgentRunner {
         run_id: input.runId,
       });
 
+      let cancelRun!: () => void;
+      const cancellation = new Promise<void>((resolve) => {
+        cancelRun = resolve;
+      });
+      let resolveCompletion!: (completed: boolean) => void;
+      const completion = new Promise<boolean>((resolve) => {
+        resolveCompletion = resolve;
+      });
       const state: ThreadState = {
         threadId,
         runId: input.runId,
@@ -249,6 +263,11 @@ export class IntelligenceAgentRunner extends AgentRunner {
         hasJoined: false,
         supportsRunnerEventBatch: false,
         producerFinished: false,
+        cancellation,
+        cancelRun,
+        completion,
+        resolveCompletion,
+        stopTimer: null,
         pendingEvents: new Map(),
         activeEventBatch: null,
         nextEventPushAttempt: 0,
@@ -258,7 +277,10 @@ export class IntelligenceAgentRunner extends AgentRunner {
         socketReconnectWatchdog: null,
         eventRetryAttempt: 0,
         completeRun: () => observer.complete(),
-        failRun: (error) => observer.error(error),
+        failRun: (error) => {
+          startupBoundary?.rejectStartup(error);
+          observer.error(error);
+        },
       };
       this.threads.set(threadId, state);
 
@@ -324,7 +346,12 @@ export class IntelligenceAgentRunner extends AgentRunner {
           payload.type === EventType.CUSTOM &&
           (payload as BaseEvent & { name?: string }).name === "stop"
         ) {
-          this.stop({ threadId, runId: state.runId });
+          this.stop({ threadId, runId: state.runId }).catch((error) => {
+            logger.error(
+              { err: error, threadId, runId: state.runId },
+              "Failed to stop Intelligence run",
+            );
+          });
         }
       });
 
@@ -472,6 +499,7 @@ export class IntelligenceAgentRunner extends AgentRunner {
     return Promise.resolve(state?.isRunning ?? false);
   }
 
+  /** Stops this run and waits until its terminal events have been acknowledged. */
   stop(request: AgentRunnerStopRequest): Promise<boolean | undefined> {
     const state = this.threads.get(request.threadId);
     if (!state || !state.isRunning || state.stopRequested) {
@@ -483,16 +511,51 @@ export class IntelligenceAgentRunner extends AgentRunner {
 
     state.stopRequested = true;
 
+    // Fence output before abort: adapters may emit synchronously, throw, or
+    // ignore cancellation. Finalization must not depend on their cooperation.
+    state.cancelRun();
+    state.stopTimer = setTimeout(() => {
+      this.failThread(
+        state.threadId,
+        state,
+        new Error("Timed out stopping Intelligence run"),
+      );
+    }, EVENT_DURABILITY_DEADLINE_MS);
+
     // Direct local abort — the runtime is the authority.
     if (state.agent) {
       try {
         state.agent.abortRun();
       } catch {
-        // Ignore abort errors.
+        // The local run is still fenced and must deliver its terminal events.
+      }
+      // Older AG-UI agents may not expose detachActiveRun. The cancellation
+      // race still finalizes their run without waiting for the producer.
+      if (typeof state.agent.detachActiveRun === "function") {
+        try {
+          Promise.resolve(state.agent.detachActiveRun()).catch((error) => {
+            logger.warn(
+              { err: error, threadId: state.threadId, runId: state.runId },
+              "Failed to detach stopped agent",
+            );
+          });
+        } catch (error) {
+          logger.warn(
+            { err: error, threadId: state.threadId, runId: state.runId },
+            "Failed to detach stopped agent",
+          );
+        }
       }
     }
 
-    return Promise.resolve(true);
+    return state.completion.then((completed) => {
+      if (!completed) {
+        throw new Error(
+          "Intelligence run stopped before terminal events were acknowledged",
+        );
+      }
+      return true;
+    });
   }
 
   private async executeAgentRun(
@@ -566,19 +629,26 @@ export class IntelligenceAgentRunner extends AgentRunner {
     };
 
     try {
-      await request.agent.runAgent(request.input, {
-        onEvent: ({ event }: { event: BaseEvent }) => {
-          if (event.type === EventType.RUN_STARTED) {
-            pushCanonicalEvent(buildRunStartedEvent(event as RunStartedEvent));
-            return;
-          }
+      if (state.stopRequested) return;
+      await Promise.race([
+        request.agent.runAgent(request.input, {
+          onEvent: ({ event }: { event: BaseEvent }) => {
+            if (state.stopRequested || state.producerFinished) return;
+            if (event.type === EventType.RUN_STARTED) {
+              pushCanonicalEvent(
+                buildRunStartedEvent(event as RunStartedEvent),
+              );
+              return;
+            }
 
-          ensureRunStarted();
-          pushCanonicalEvent(event);
-        },
-      });
+            ensureRunStarted();
+            pushCanonicalEvent(event);
+          },
+        }),
+        state.cancellation,
+      ]);
     } catch (error) {
-      if (!this.isCurrentThreadState(threadId, state)) {
+      if (state.stopRequested || !this.isCurrentThreadState(threadId, state)) {
         return;
       }
       ensureRunStarted();
@@ -883,7 +953,7 @@ export class IntelligenceAgentRunner extends AgentRunner {
       return;
     }
 
-    this.removeThread(threadId, state);
+    this.removeThread(threadId, state, true);
     state.completeRun();
   }
 
@@ -1000,7 +1070,11 @@ export class IntelligenceAgentRunner extends AgentRunner {
    * Idempotent — safe to call multiple times for the same threadId
    * (e.g. from join error handlers, finalize, and Observable teardown).
    */
-  private removeThread(threadId: string, state: ThreadState): void {
+  private removeThread(
+    threadId: string,
+    state: ThreadState,
+    completed = false,
+  ): void {
     if (this.threads.get(threadId) !== state) {
       return;
     }
@@ -1008,6 +1082,11 @@ export class IntelligenceAgentRunner extends AgentRunner {
     // Delete first so concurrent calls see the entry as already removed.
     this.threads.delete(threadId);
     state.isRunning = false;
+    state.resolveCompletion(completed);
+    if (state.stopTimer !== null) {
+      clearTimeout(state.stopTimer);
+      state.stopTimer = null;
+    }
     this.clearPendingEventRetry(state);
     this.clearPendingEventFlush(state);
     if (state.eventDeadlineTimer !== null) {


### PR DESCRIPTION
## What does this PR do?

Fixes Stop → resend on Intelligence threads. `IntelligenceAgentRunner.stop()` previously returned `true` after requesting an abort, while the handler kept renewing the hosted lock. Agents that ignored abort could keep the thread locked until natural completion.

Stop now fences late producer events, requests cancellation, and finalizes the run through the existing event queue. It resolves `true` only after the gateway acknowledges every queued event and the runner completes cleanup. The gateway's existing terminal-event handling releases only that run's lock. Cancellation does not depend on the agent promise settling; AG-UI subscriptions also detach when the agent supports it. Delivery rejection, teardown, or the 60-second deadline cannot report success.

### Compatibility

- No Intelligence or AG-UI server change, new event type, required capability, dependency bump, or coordinated rollout.
- Existing single-event and batched acknowledgments both work. Older agents without `detachActiveRun()` retain the cancellation fallback.
- HTTP paths, empty-body requests, single-route envelopes, and response bodies are unchanged. Missing, mismatched, and duplicate Stop requests retain `false`.
- The existing optional runner `runId` remains supported. This PR does not duplicate #6982's HTTP run-selection change.
- Provider cancellation remains best effort; stopping a run cannot undo external tool effects.

### Validation

- RED: the new legacy/batch transport tests failed because no terminal event followed a non-cooperative abort. The subscription-cleanup test separately failed before detachment was added.
- GREEN: 11 new tests exercise real Phoenix WebSocket framing, delayed terminal acceptance, immediate resend, older agents, throwing aborts, late events, partial messages/tools, pre-join Stop, rejection, timeout, and both HTTP route modes. All 2,306 runtime tests and the existing runner tests pass.
- `pnpm nx run-many -t test,check-types,build,publint,attw --projects=@copilotkit/runtime --parallel=2` passed again after rebasing onto current main.
- The 11 new transport and HTTP tests also passed on Node 20.19.4; the fixture supplies WebSocket only when the Node global is absent.
- The required pre-commit check passed tests and package validation for nine affected packages. An initial parallel run timed out in the unrelated SQLite replay test; its isolated rerun passed all 15 tests, followed by a passing hook with `NX_PARALLEL=2`. No test timeout changed.
- Focused oxlint and oxfmt checks; `git diff --check`. Oxlint reports only three existing warnings in the runner and its older test file.
- Local integration: the actual runtime HTTP handler and a gateway built from Intelligence `a55679d1055ab831930331e64b6129d14e73b613`, with isolated Redis/PostgreSQL. App API lock acquisition/renewal were represented by a test adapter over real Redis. Two consecutive streamed runs stopped in 179 ms and 156 ms; each response followed lock release. PostgreSQL retained both ordered five-event sequences, one `RUN_FINISHED` per run, and no `RUN_ERROR`. The fixture included the current replay-projection migration.

## Related PRs and Issues

Closes #7078.
Related: #6982 (HTTP selection of an exact run).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stopping an Intelligence run now waits for terminal confirmation before completing.
  * Stop requests prevent late events and clean up local run subscriptions.
  * Runs can be stopped at different connection stages, including before channel join.
  * Partial text and tool-call streams are properly closed when stopping.
  * Stop failures and durability timeouts are surfaced appropriately.
  * HTTP Stop endpoint behavior is preserved while waiting for run completion.

* **Documentation**
  * Added guidance on stopping runs, cancellation ordering, failure handling, and gateway acknowledgments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->