### PR TITLE
fix(inspector): remove optional feedback prompt copy

### DIFF
--- a/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
+++ b/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
@@ -1340,6 +1340,7 @@ test("Home feature actions copy correlated onboarding prompts", async () => {
       // cannot grant it to itself.
       expect(prompt).toContain("Help me set this up in my CopilotKit app.");
       expect(prompt).not.toContain("Identify your coding-agent slug");
+      expect(prompt).toContain("Never reveal credentials");
       expect(prompt).not.toContain("optional diagnostic feedback");
       // The A2UI route owns the guide link, the plan and the proof step. The
       // button's whole job is to name the outcome.

--- a/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
+++ b/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
@@ -1340,9 +1340,7 @@ test("Home feature actions copy correlated onboarding prompts", async () => {
       // cannot grant it to itself.
       expect(prompt).toContain("Help me set this up in my CopilotKit app.");
       expect(prompt).not.toContain("Identify your coding-agent slug");
-      expect(prompt).toContain(
-        "Never reveal credentials or send optional diagnostic feedback reports",
-      );
+      expect(prompt).not.toContain("optional diagnostic feedback");
       // The A2UI route owns the guide link, the plan and the proof step. The
       // button's whole job is to name the outcome.
       expect(prompt).toContain("--intent add-a2ui");

--- a/packages/web-inspector/src/lib/onboarding-prompt.ts
+++ b/packages/web-inspector/src/lib/onboarding-prompt.ts
@@ -144,7 +144,7 @@ export const FEATURE_ONBOARDING_PROMPT_TEMPLATE =
   "instructions:\n\nnpx --yes copilotkit@latest onboard start --run " +
   `${RUN_ID_PLACEHOLDER} --intent ${INTENT_PLACEHOLDER}` +
   "\n\nIf it requires a CopilotKit CLI session check, you have permission to " +
-  "run it.";
+  "run it. Never reveal credentials.";
 
 /** Bind one run id and one tile's feature outcome into the copied prompt. */
 export function createFeatureOnboardingPrompt(

--- a/packages/web-inspector/src/lib/onboarding-prompt.ts
+++ b/packages/web-inspector/src/lib/onboarding-prompt.ts
@@ -144,8 +144,7 @@ export const FEATURE_ONBOARDING_PROMPT_TEMPLATE =
   "instructions:\n\nnpx --yes copilotkit@latest onboard start --run " +
   `${RUN_ID_PLACEHOLDER} --intent ${INTENT_PLACEHOLDER}` +
   "\n\nIf it requires a CopilotKit CLI session check, you have permission to " +
-  "run it. Never reveal credentials or send optional diagnostic feedback " +
-  "reports.";
+  "run it.";
 
 /** Bind one run id and one tile's feature outcome into the copied prompt. */
 export function createFeatureOnboardingPrompt(


### PR DESCRIPTION
## Problem

Inspector feature setup prompts included an unnecessary optional diagnostic-feedback instruction.

## Why

Threads and Learning use this shared feature CTA prompt, so the extra instruction was copied into their onboarding flow.

## Fix

Remove the instruction from the shared template and assert it is absent in the navigation test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Updated the onboarding prompt to retain the instruction not to reveal credentials.
  - Removed the instruction referring to optional diagnostic feedback reports.

- **Tests**
  - Updated onboarding navigation coverage to verify the credential protection wording and ensure the removed diagnostic feedback wording is not present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->