### PR TITLE
fix(runtime): preserve Responses and Anthropic reasoning metadata

### DIFF
--- a/packages/runtime/src/agent/__tests__/basic-agent.test.ts
+++ b/packages/runtime/src/agent/__tests__/basic-agent.test.ts
@@ -1073,6 +1073,46 @@ describe("BasicAgent", () => {
       expect(eventTypes).toContain(EventType.RUN_FINISHED);
     });
 
+    it("should preserve reasoning provider metadata in classic mode", async () => {
+      const agent = new BasicAgent({ model: "anthropic/claude-sonnet-4-5" });
+
+      vi.mocked(streamText).mockReturnValue(
+        mockStreamTextResponse([
+          reasoningStart("reasoning-anthropic"),
+          reasoningDelta("thinking"),
+          {
+            type: "reasoning-delta",
+            text: "",
+            providerMetadata: {
+              anthropic: { signature: "thinking-signature" },
+            },
+          },
+          reasoningEnd(),
+          finish(),
+        ]) as any,
+      );
+
+      const input: RunAgentInput = {
+        threadId: "thread1",
+        runId: "run1",
+        messages: [],
+        tools: [],
+        context: [],
+        state: {},
+      };
+      const events = await collectEvents(agent["run"](input));
+
+      expect(
+        events.find((event) => event.type === EventType.REASONING_MESSAGE_END),
+      ).toMatchObject({
+        metadata: {
+          aiSdkProviderMetadata: {
+            anthropic: { signature: "thinking-signature" },
+          },
+        },
+      });
+    });
+
     it("should handle reasoning-only stream (no text output)", async () => {
       const agent = new BasicAgent({
         model: "openai/gpt-4o",

--- a/packages/runtime/src/agent/__tests__/converter-aisdk.test.ts
+++ b/packages/runtime/src/agent/__tests__/converter-aisdk.test.ts
@@ -349,6 +349,68 @@ describe("AI SDK Converter", () => {
       );
     });
 
+    it("preserves provider metadata from empty reasoning deltas", async () => {
+      const agent = createAgent("aisdk", [
+        reasoningStart("r-anthropic"),
+        reasoningDelta("thinking"),
+        {
+          type: "reasoning-delta",
+          text: "",
+          providerMetadata: {
+            anthropic: { signature: "thinking-signature" },
+          },
+        },
+        reasoningEnd(),
+        finish(),
+      ]);
+      const events = await collectEvents(agent.run(createDefaultInput()));
+
+      const endEvent = events.find(
+        (event) => event.type === EventType.REASONING_MESSAGE_END,
+      );
+      expect(endEvent).toMatchObject({
+        metadata: {
+          aiSdkProviderMetadata: {
+            anthropic: { signature: "thinking-signature" },
+          },
+        },
+      });
+    });
+
+    it("merges Responses reasoning metadata across stream parts", async () => {
+      const agent = createAgent("aisdk", [
+        {
+          type: "reasoning-start",
+          id: "r-openai",
+          providerMetadata: { openai: { itemId: "rs_123" } },
+        },
+        reasoningDelta("summary"),
+        {
+          type: "reasoning-end",
+          id: "r-openai",
+          providerMetadata: {
+            openai: { reasoningEncryptedContent: "encrypted-reasoning" },
+          },
+        },
+        finish(),
+      ]);
+      const events = await collectEvents(agent.run(createDefaultInput()));
+
+      const endEvent = events.find(
+        (event) => event.type === EventType.REASONING_MESSAGE_END,
+      );
+      expect(endEvent).toMatchObject({
+        metadata: {
+          aiSdkProviderMetadata: {
+            openai: {
+              itemId: "rs_123",
+              reasoningEncryptedContent: "encrypted-reasoning",
+            },
+          },
+        },
+      });
+    });
+
     it("auto-close reasoning before text-delta", async () => {
       // No explicit reasoning-end — the converter should auto-close
       const agent = createAgent("aisdk", [

--- a/packages/runtime/src/agent/__tests__/utils.test.ts
+++ b/packages/runtime/src/agent/__tests__/utils.test.ts
@@ -152,6 +152,109 @@ describe("convertMessagesToVercelAISDKMessages", () => {
     });
   });
 
+  it("should ignore reasoning without provider metadata", () => {
+    const messages: Message[] = [
+      {
+        id: "reasoning-1",
+        role: "reasoning",
+        content: "Reasoning without provider metadata.",
+      },
+      { id: "assistant-1", role: "assistant", content: "answer" },
+    ];
+
+    expect(convertMessagesToVercelAISDKMessages(messages)).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "answer" }],
+      },
+    ]);
+  });
+
+  it("should preserve Anthropic reasoning before the assistant response", () => {
+    const messages: Message[] = [
+      {
+        id: "reasoning-1",
+        role: "reasoning",
+        content: "Let me inspect the available tools.",
+        metadata: {
+          aiSdkProviderMetadata: {
+            anthropic: { signature: "thinking-signature" },
+          },
+        },
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        toolCalls: [
+          {
+            id: "call-1",
+            type: "function",
+            function: { name: "search", arguments: '{"query":"test"}' },
+          },
+        ],
+      },
+    ];
+
+    expect(convertMessagesToVercelAISDKMessages(messages)).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "Let me inspect the available tools.",
+            providerOptions: {
+              anthropic: { signature: "thinking-signature" },
+            },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "search",
+            input: { query: "test" },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("should preserve Responses reasoning item metadata", () => {
+    const messages: Message[] = [
+      {
+        id: "reasoning-1",
+        role: "reasoning",
+        content: "summary",
+        metadata: {
+          aiSdkProviderMetadata: {
+            openai: {
+              itemId: "rs_123",
+              reasoningEncryptedContent: "encrypted-reasoning",
+            },
+          },
+        },
+      },
+      { id: "assistant-1", role: "assistant", content: "answer" },
+    ];
+
+    expect(convertMessagesToVercelAISDKMessages(messages)).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "summary",
+            providerOptions: {
+              openai: {
+                itemId: "rs_123",
+                reasoningEncryptedContent: "encrypted-reasoning",
+              },
+            },
+          },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ]);
+  });
+
   it("should convert tool messages", () => {
     const messages: Message[] = [
       {

--- a/packages/runtime/src/agent/converters/aisdk.ts
+++ b/packages/runtime/src/agent/converters/aisdk.ts
@@ -19,6 +19,11 @@ import { randomUUID } from "@copilotkit/shared";
 import { createStateEventNormalizer } from "../state-delta";
 import { aggregateRunUsage, getTokenCount, tokenCountKeys } from "./usage";
 import type { AgentRunFinishedDetails, AgentRunUsage } from "./usage";
+import {
+  mergeAISDKProviderMetadata,
+  reasoningEventMetadata,
+} from "./reasoning-metadata";
+import type { ProviderMetadata } from "ai";
 
 /**
  * Reads aggregate usage from an AI SDK finish part without inventing values
@@ -81,6 +86,7 @@ export async function* convertAISDKStream(
   let messageId = randomUUID();
   let reasoningMessageId = randomUUID();
   let isInReasoning = false;
+  let reasoningProviderMetadata: ProviderMetadata | undefined;
   const normalizeStateEvent = createStateEventNormalizer(initialState);
 
   const toolCallStates = new Map<
@@ -112,10 +118,13 @@ export async function* convertAISDKStream(
   function* closeReasoningIfOpen(): Generator<BaseEvent> {
     if (!isInReasoning) return;
     isInReasoning = false;
+    const metadata = reasoningEventMetadata(reasoningProviderMetadata);
     const reasoningMsgEnd: ReasoningMessageEndEvent = {
       type: EventType.REASONING_MESSAGE_END,
       messageId: reasoningMessageId,
+      ...(metadata ? { metadata } : {}),
     };
+    reasoningProviderMetadata = undefined;
     yield reasoningMsgEnd;
     const reasoningEnd: ReasoningEndEvent = {
       type: EventType.REASONING_END,
@@ -128,9 +137,15 @@ export async function* convertAISDKStream(
     for await (const part of fullStream) {
       const p = part as Record<string, unknown>;
 
-      // Close any open reasoning lifecycle on every event except
-      // reasoning-delta, which arrives mid-block and must not interrupt it.
-      if (p.type !== "reasoning-delta") {
+      if (p.type === "reasoning-delta" || p.type === "reasoning-end") {
+        reasoningProviderMetadata = mergeAISDKProviderMetadata(
+          reasoningProviderMetadata,
+          p.providerMetadata,
+        );
+      }
+
+      // Close an open reasoning lifecycle before starting any unrelated part.
+      if (p.type !== "reasoning-delta" && p.type !== "reasoning-end") {
         yield* closeReasoningIfOpen();
       }
 
@@ -148,6 +163,10 @@ export async function* convertAISDKStream(
             providedId && providedId !== "0"
               ? (providedId as string)
               : randomUUID();
+          reasoningProviderMetadata = mergeAISDKProviderMetadata(
+            undefined,
+            p.providerMetadata,
+          );
           const reasoningStartEvent: ReasoningStartEvent = {
             type: EventType.REASONING_START,
             messageId: reasoningMessageId,
@@ -176,8 +195,7 @@ export async function* convertAISDKStream(
         }
 
         case "reasoning-end": {
-          // closeReasoningIfOpen() already called before the switch — no-op here
-          // if the SDK never emits this event (e.g. @ai-sdk/anthropic).
+          yield* closeReasoningIfOpen();
           break;
         }
 

--- a/packages/runtime/src/agent/converters/reasoning-metadata.ts
+++ b/packages/runtime/src/agent/converters/reasoning-metadata.ts
@@ -1,0 +1,58 @@
+import type { Message } from "@ag-ui/client";
+import type { ProviderMetadata } from "ai";
+
+const AI_SDK_PROVIDER_METADATA_KEY = "aiSdkProviderMetadata";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseProviderMetadata(value: unknown): ProviderMetadata | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    throw new Error("AI SDK provider metadata must be an object");
+  }
+
+  for (const [provider, metadata] of Object.entries(value)) {
+    if (!isRecord(metadata)) {
+      throw new Error(
+        `AI SDK provider metadata for "${provider}" must be an object`,
+      );
+    }
+  }
+
+  return value as ProviderMetadata;
+}
+
+export function mergeAISDKProviderMetadata(
+  current: ProviderMetadata | undefined,
+  incoming: unknown,
+): ProviderMetadata | undefined {
+  const parsed = parseProviderMetadata(incoming);
+  if (!parsed) return current;
+
+  const merged: ProviderMetadata = { ...current };
+  for (const [provider, metadata] of Object.entries(parsed)) {
+    merged[provider] = {
+      ...current?.[provider],
+      ...metadata,
+    };
+  }
+  return merged;
+}
+
+export function reasoningEventMetadata(
+  providerMetadata: ProviderMetadata | undefined,
+): Record<string, unknown> | undefined {
+  return providerMetadata
+    ? { [AI_SDK_PROVIDER_METADATA_KEY]: providerMetadata }
+    : undefined;
+}
+
+export function reasoningMessageProviderOptions(
+  message: Message,
+): ProviderMetadata | undefined {
+  return parseProviderMetadata(
+    message.metadata?.[AI_SDK_PROVIDER_METADATA_KEY],
+  );
+}

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -37,6 +37,7 @@ import type {
   ToolChoice,
   ToolSet,
   Schema,
+  ProviderMetadata,
 } from "ai";
 import { streamText, tool as createVercelAISDKTool, stepCountIs } from "ai";
 import { createMCPClient } from "@ai-sdk/mcp";
@@ -62,6 +63,11 @@ import {
   isRecord,
 } from "./converters/usage";
 import type { AgentRunFinishedDetails } from "./converters/usage";
+import {
+  mergeAISDKProviderMetadata,
+  reasoningEventMetadata,
+  reasoningMessageProviderOptions,
+} from "./converters/reasoning-metadata";
 import { createStateEventNormalizer } from "./state-delta";
 import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -492,27 +498,35 @@ export function convertMessagesToVercelAISDKMessages(
   options: MessageConversionOptions = {},
 ): ModelMessage[] {
   const result: ModelMessage[] = [];
+  type AssistantContent = Exclude<AssistantModelMessage["content"], string>;
+  let pendingReasoning: AssistantContent = [];
+
+  const flushPendingReasoning = () => {
+    if (pendingReasoning.length === 0) return;
+    result.push({ role: "assistant", content: pendingReasoning });
+    pendingReasoning = [];
+  };
 
   for (const message of messages) {
-    if (message.role === "system" && options.forwardSystemMessages) {
-      const systemMsg: SystemModelMessage = {
-        role: "system",
-        content: message.content ?? "",
-      };
-      result.push(systemMsg);
-    } else if (
-      message.role === "developer" &&
-      options.forwardDeveloperMessages
-    ) {
-      const systemMsg: SystemModelMessage = {
-        role: "system",
-        content: message.content ?? "",
-      };
-      result.push(systemMsg);
-    } else if (message.role === "assistant") {
-      const parts: Array<TextPart | ToolCallPart> = message.content
-        ? [{ type: "text", text: message.content }]
-        : [];
+    if (message.role === "reasoning") {
+      const providerOptions = reasoningMessageProviderOptions(message);
+      if (providerOptions) {
+        pendingReasoning.push({
+          type: "reasoning",
+          text: message.content,
+          providerOptions,
+        });
+      }
+      continue;
+    }
+
+    if (message.role === "assistant") {
+      const parts: AssistantContent = [...pendingReasoning];
+      pendingReasoning = [];
+
+      if (message.content) {
+        parts.push({ type: "text", text: message.content });
+      }
 
       for (const toolCall of message.toolCalls ?? []) {
         const toolCallPart: ToolCallPart = {
@@ -529,6 +543,26 @@ export function convertMessagesToVercelAISDKMessages(
         content: parts,
       };
       result.push(assistantMsg);
+      continue;
+    }
+
+    flushPendingReasoning();
+
+    if (message.role === "system" && options.forwardSystemMessages) {
+      const systemMsg: SystemModelMessage = {
+        role: "system",
+        content: message.content ?? "",
+      };
+      result.push(systemMsg);
+    } else if (
+      message.role === "developer" &&
+      options.forwardDeveloperMessages
+    ) {
+      const systemMsg: SystemModelMessage = {
+        role: "system",
+        content: message.content ?? "",
+      };
+      result.push(systemMsg);
     } else if (message.role === "user") {
       const userMsg: UserModelMessage = {
         role: "user",
@@ -566,6 +600,8 @@ export function convertMessagesToVercelAISDKMessages(
       result.push(toolMsg);
     }
   }
+
+  flushPendingReasoning();
 
   return result;
 }
@@ -1306,6 +1342,7 @@ export class BuiltInAgent extends AbstractAgent {
         let messageId = randomUUID();
         let reasoningMessageId = randomUUID();
         let isInReasoning = false;
+        let reasoningProviderMetadata: ProviderMetadata | undefined;
 
         // Auto-close an open reasoning lifecycle.
         // Some AI SDK providers (notably @ai-sdk/anthropic) never emit "reasoning-end",
@@ -1316,10 +1353,13 @@ export class BuiltInAgent extends AbstractAgent {
         const closeReasoningIfOpen = () => {
           if (!isInReasoning) return;
           isInReasoning = false;
+          const metadata = reasoningEventMetadata(reasoningProviderMetadata);
           const reasoningMsgEnd: ReasoningMessageEndEvent = {
             type: EventType.REASONING_MESSAGE_END,
             messageId: reasoningMessageId,
+            ...(metadata ? { metadata } : {}),
           };
+          reasoningProviderMetadata = undefined;
           subscriber.next(reasoningMsgEnd);
           const reasoningEnd: ReasoningEndEvent = {
             type: EventType.REASONING_END,
@@ -1508,9 +1548,21 @@ export class BuiltInAgent extends AbstractAgent {
 
           // Process fullStream events
           for await (const part of response.fullStream) {
-            // Close any open reasoning lifecycle on every event except
-            // reasoning-delta, which arrives mid-block and must not interrupt it.
-            if (part.type !== "reasoning-delta") {
+            if (
+              part.type === "reasoning-delta" ||
+              part.type === "reasoning-end"
+            ) {
+              reasoningProviderMetadata = mergeAISDKProviderMetadata(
+                reasoningProviderMetadata,
+                part.providerMetadata,
+              );
+            }
+
+            // Close an open reasoning lifecycle before any unrelated part.
+            if (
+              part.type !== "reasoning-delta" &&
+              part.type !== "reasoning-end"
+            ) {
               closeReasoningIfOpen();
             }
 
@@ -1540,6 +1592,10 @@ export class BuiltInAgent extends AbstractAgent {
                 reasoningMessageId = isNonUniqueId
                   ? randomUUID()
                   : (providedId as typeof reasoningMessageId);
+                reasoningProviderMetadata = mergeAISDKProviderMetadata(
+                  undefined,
+                  part.providerMetadata,
+                );
                 const reasoningStartEvent: ReasoningStartEvent = {
                   type: EventType.REASONING_START,
                   messageId: reasoningMessageId,
@@ -1566,8 +1622,7 @@ export class BuiltInAgent extends AbstractAgent {
                 break;
               }
               case "reasoning-end": {
-                // closeReasoningIfOpen() already called before the switch — no-op here
-                // if the SDK never emits this event (e.g. @ai-sdk/anthropic).
+                closeReasoningIfOpen();
                 break;
               }
               case "tool-input-start": {


### PR DESCRIPTION
## What does this PR do?

Fixes multi-turn reasoning with DeepSeek endpoints exposed through the OpenAI Responses-compatible and Anthropic Messages APIs.

AI SDK emits provider-owned reasoning metadata separately from the visible reasoning text. CopilotKit converted the text into AG-UI events but discarded that metadata, so persisted turns could not return the required reasoning state on the next request. Providers then rejected the continuation with errors such as reasoning_text or thinking must be passed back to the API.

This PR:

- carries reasoning provider metadata through REASONING_MESSAGE_END metadata;
- merges OpenAI Responses item identifiers and encrypted reasoning content across stream parts;
- preserves Anthropic thinking signatures, including signatures delivered on empty reasoning deltas;
- reconstructs AI SDK reasoning parts with providerOptions before the corresponding assistant response;
- ignores reasoning messages without provider metadata, leaving Chat Completions behavior unchanged.

The change is limited to the Runtime AI SDK reasoning conversion path and focused regression tests. It does not change dependencies, package installation, MCP/tool registration, or application code.

## Related PRs and Issues

- No linked issue.

## Verification

- pnpm exec nx test @copilotkit/runtime: 167 files, 2349 tests passed
- pnpm exec nx check-types @copilotkit/runtime: passed
- pre-commit test, publint, and attw checks: passed

## Checklist

- [x] I have read the Contribution Guide
- [x] Documentation is not required for this internal protocol round-trip fix
- [x] Allow edits by maintainers is enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved provider metadata attached to reasoning events during streaming.
  * Combined metadata from reasoning start, delta, and end events for consistent results.
  * Preserved Anthropic and OpenAI reasoning details when converting messages for the AI SDK.
  * Correctly positioned reasoning content before related text or tool-call content.
  * Excluded reasoning messages that do not contain provider metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->