### PR TITLE
LangGraph Middleware: use interrupt() to wait frontend tool results

### DIFF
--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -14,10 +14,8 @@ Example:
     )
 """
 
-import asyncio
 import json
 import re
-import sys
 from typing import Any, Callable, Awaitable, ClassVar, Iterable, Optional, Union
 
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
@@ -147,14 +145,6 @@ def _parse_frontend_tool_results(payload: Any) -> Any:
             # Last wins, so a client retrying one call in the same batch is fine.
             results[tool_call_id] = content
     return results
-
-
-def _in_async_task() -> bool:
-    """Whether we are executing inside a running asyncio task."""
-    try:
-        return asyncio.current_task() is not None
-    except RuntimeError:
-        return False
 
 
 def _current_thread_id() -> "str | None":
@@ -355,17 +345,13 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             appended, so the model finishes the turn with the results in hand,
             in natural ``AIMessage`` → ``ToolMessage`` order. ``True`` requires:
 
-            1. **Python 3.11+ when async**, which the runtime always is: below
-               3.11 the run config does not reach asyncio tasks, so *any* async
-               ``interrupt()`` cannot read it. Raises ``CopilotKitMisuseError``,
-               not ``Called get_config outside of a runnable context``.
-            2. **An explicit client resume** — the default frontend-tool loop
+            1. **An explicit client resume** — the default frontend-tool loop
                fires a follow-up run with no resume command, which an
                interrupted thread ignores. Mount a handler that reads
                ``__copilotkit_frontend_tool_calls__`` off the interrupt and
                resumes with ``{"tool_results": [{"toolCallId": ...,
                "content": ...}, ...]}``.
-            3. **One interrupt per turn** — a resume cannot address multiple
+            2. **One interrupt per turn** — a resume cannot address multiple
                pending interrupts without interrupt ids
                (ag-ui-protocol/ag-ui#2178), so batching is mandatory.
     """
@@ -1187,34 +1173,6 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             t.get("function", {}).get("name") or t.get("name") for t in frontend_tools
         }
 
-    @staticmethod
-    def _check_interrupt_preconditions() -> None:
-        """Fail early, and actionably, when interrupt mode cannot work.
-
-        On Python 3.10 the run config does not propagate into asyncio tasks, so
-        ``interrupt()`` cannot read it and dies with LangGraph's opaque ``Called
-        get_config outside of a runnable context``. This applies to any
-        ``interrupt()`` from an async node, not just this flag.
-        """
-        try:
-            from langgraph.config import get_config
-
-            get_config()
-        except RuntimeError as error:
-            if sys.version_info < (3, 11) and _in_async_task():
-                raise CopilotKitMisuseError(
-                    "CopilotKitMiddleware(interrupt_frontend_tools=True) needs "
-                    "Python 3.11+ when the agent runs asynchronously: on 3.10 the "
-                    "run config does not propagate into asyncio tasks, so "
-                    "LangGraph's interrupt() cannot read it. Upgrade to 3.11+, or "
-                    "leave the flag off to use the default frontend-tool flow."
-                ) from error
-            # Not inside a runnable context at all (e.g. a direct unit-test
-            # call) — nothing to validate.
-            return
-        except Exception:  # noqa: BLE001 - never block a run on a probe failure
-            return
-
     # Intercept frontend tool calls after model returns, before ToolNode executes.
     #
     # NOTE: this hook must stay free of side effects. In interrupt mode
@@ -1294,8 +1252,6 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         # this node finds nothing outstanding instead of interrupting again.
         if not frontend_calls:
             return None
-
-        self._check_interrupt_preconditions()
 
         # One interrupt for the whole batch. A resume carries a single value and
         # cannot address several pending interrupts without their ids

--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -320,27 +320,16 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             model (the host cannot supply the live, header-hooked model), and
             folds the registered catalog id + component schema into the params
             unless the host already set them — so host values win.
-        interrupt_frontend_tools: Await frontend tool results *in the same
-            turn* via LangGraph's ``interrupt()``, instead of the default
-            strip-and-restore.
+        interrupt_frontend_tools: Await frontend tool results in the same turn
+            via LangGraph's ``interrupt()``, instead of the default
+            strip-and-restore that only delivers them on the next run.
 
-            ``False`` (default) strips the calls off the ``AIMessage`` in
-            ``after_model`` and restores them in ``after_agent``, so the result
-            only lands on the next run, never in-run. ``True`` batches a turn's
-            calls into one ``interrupt()``: the graph pauses, the client runs
-            the tools and resumes, and one real ``ToolMessage`` per call is
-            appended, so the model finishes the turn with the results in hand,
-            in natural ``AIMessage`` → ``ToolMessage`` order. ``True`` requires:
-
-            1. **An explicit client resume** — the default frontend-tool loop
-               fires a follow-up run with no resume command, which an
-               interrupted thread ignores. Mount a handler that reads
-               ``__copilotkit_frontend_tool_calls__`` off the interrupt and
-               resumes with ``{"tool_results": [{"toolCallId": ...,
-               "content": ...}, ...]}``.
-            2. **One interrupt per turn** — a resume cannot address multiple
-               pending interrupts without interrupt ids
-               (ag-ui-protocol/ag-ui#2178), so batching is mandatory.
+            Batches a turn's calls into one ``interrupt()`` keyed
+            ``__copilotkit_frontend_tool_calls__``; the client resumes with
+            ``{"tool_results": [{"toolCallId": ..., "content": ...}, ...]}`` and
+            one ``ToolMessage`` per call is appended. Needs an explicit resume —
+            the default frontend-tool loop fires a follow-up run that an
+            interrupted thread ignores.
     """
 
     state_schema = StateSchema
@@ -1160,9 +1149,6 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             t.get("function", {}).get("name") or t.get("name") for t in frontend_tools
         }
 
-    # Intercept frontend tool calls after the model returns, before ToolNode runs.
-    # Must stay side-effect free: in interrupt mode ``interrupt()`` raises out of
-    # here, so the node re-runs from the top on resume.
     def after_model(
         self,
         state: StateSchema,

--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -14,8 +14,10 @@ Example:
     )
 """
 
+import asyncio
 import json
 import re
+import sys
 from typing import Any, Callable, Awaitable, ClassVar, Iterable, Optional, Union
 
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
@@ -26,7 +28,9 @@ from langchain.agents.middleware import (
     ModelResponse,
 )
 from langgraph.runtime import Runtime
+from langgraph.types import interrupt
 
+from .exc import CopilotKitMisuseError
 from .header_propagation import install_httpx_hook, set_forwarded_headers
 from .langgraph import CopilotKitProperties
 
@@ -61,6 +65,97 @@ _a2ui_tools_by_thread: dict[str, Any] = {}
 # acceptable edge — the deployed path always carries a thread id.
 _DEFAULT_THREAD_KEY = "__copilotkit_a2ui_default__"
 _FRONTEND_TOOL_RESULT_CONTENT = json.dumps({"status": "forwarded_to_frontend"})
+
+# Placeholder LangGraph's ``patch_orphan_tool_calls`` writes for a tool call that
+# was still pending when a checkpoint was saved. Hoisted to module scope so both
+# ``_fix_messages_for_bedrock`` and the interrupt path can match it without
+# recompiling the pattern on every call.
+_INTERRUPTED_PAT = re.compile(
+    r"^Tool call '.+' with id '.+' was interrupted before completion\.$"
+)
+
+# Key carrying the batched frontend tool calls in the interrupt payload emitted
+# when ``interrupt_frontend_tools`` is on. Namespaced so a client can tell this
+# apart from a human-facing interrupt on the same thread (e.g. via
+# ``useInterrupt({ enabled })``). Deliberately NOT ``__copilotkit_interrupt_value__``
+# — that envelope means "render this to the user", which this is not.
+_FE_INTERRUPT_KEY = "__copilotkit_frontend_tool_calls__"
+
+# Content used when the client resumed without answering a frontend tool call.
+# Every call still gets a ToolMessage so no tool_call is left unpaired.
+_MISSING_TOOL_RESULT_CONTENT = json.dumps({"ok": False, "error": "missing_tool_result"})
+
+# Sentinel distinguishing "resumed with no results" from "this resume payload
+# was never meant for us" (e.g. a human interrupt's answer was consumed first).
+_UNRECOGNIZED_RESUME = object()
+
+
+def _coerce_result(raw: dict) -> "tuple[str, str]":
+    """Normalise one client tool result into ``(tool_call_id, content)``.
+
+    Accepts the id under ``toolCallId`` (the wire casing), ``tool_call_id`` or
+    ``id``, and the payload under ``content`` or ``result``. Non-string content
+    is JSON-encoded, since ``ToolMessage.content`` has to be a string.
+    """
+    tool_call_id = raw.get("toolCallId") or raw.get("tool_call_id") or raw.get("id")
+    content = raw.get("content")
+    if content is None:
+        content = raw.get("result")
+    if not isinstance(content, str):
+        content = json.dumps(content) if content is not None else ""
+    return (str(tool_call_id) if tool_call_id is not None else "", content)
+
+
+def _parse_frontend_tool_results(payload: Any) -> Any:
+    """Normalise a resume payload into ``{tool_call_id: content}``.
+
+    The wire shape is ``forwardedProps.command.resume = {"tool_results": [...]}``,
+    which ``ag_ui_langgraph`` passes to ``Command(resume=...)`` verbatim. It
+    JSON-decodes string payloads first, so the ``str`` branch here only matters
+    for callers driving the graph directly. A bare list is accepted too.
+
+    Returns ``_UNRECOGNIZED_RESUME`` when the payload is not a tool-result
+    container at all. That case is worth failing loudly on: a single
+    ``Command(resume=...)`` carries one value and the first pending interrupt
+    consumes it, so another interrupt's answer (say ``{"approved": True}``) can
+    land here. Turning that into "no tool ran" would leave the developer
+    debugging a model apology instead of a wiring mistake. A well-formed but
+    empty container (``{"tool_results": []}``) is *not* unrecognised — that is a
+    client legitimately answering nothing, and every call gets a placeholder.
+    """
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except (TypeError, ValueError):
+            return _UNRECOGNIZED_RESUME
+
+    if isinstance(payload, dict):
+        raw_results = payload.get("tool_results")
+    elif isinstance(payload, list):
+        raw_results = payload
+    else:
+        return _UNRECOGNIZED_RESUME
+
+    if not isinstance(raw_results, list):
+        return _UNRECOGNIZED_RESUME
+
+    results: dict[str, str] = {}
+    for raw in raw_results:
+        if not isinstance(raw, dict):
+            continue
+        tool_call_id, content = _coerce_result(raw)
+        if tool_call_id:
+            # Last wins, so a client retrying one call in the same batch is fine.
+            results[tool_call_id] = content
+    return results
+
+
+def _in_async_task() -> bool:
+    """Whether we are executing inside a running asyncio task."""
+    try:
+        return asyncio.current_task() is not None
+    except RuntimeError:
+        return False
 
 
 def _current_thread_id() -> "str | None":
@@ -249,6 +344,42 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             model (the host cannot supply the live, header-hooked model), and
             folds the registered catalog id + component schema into the params
             unless the host already set them — so host values win.
+        interrupt_frontend_tools: Opt in to awaiting frontend tool results
+            *within* the same agent turn, using LangGraph's native
+            ``interrupt()`` instead of the default strip-and-restore.
+
+            - ``False`` (default) — frontend tool calls are stripped off the
+              ``AIMessage`` in ``after_model`` and restored in ``after_agent``;
+              the real result only lands on the next run. The agent never awaits
+              it in-run.
+            - ``True`` — every frontend tool call in a turn is batched into a
+              single ``interrupt()``. The graph pauses, the client executes the
+              tools and resumes, and one real ``ToolMessage`` per call is
+              appended — so the model continues the same turn with the results
+              in hand, in the natural ``AIMessage`` → ``ToolMessage`` order.
+
+            Four requirements come with ``True``:
+
+            1. **A checkpointer is mandatory.** ``interrupt()`` cannot resume
+               without one; the middleware raises ``CopilotKitMisuseError``
+               rather than letting the run fail later with LangGraph's
+               ``Cannot use Command(resume=...) without checkpointer``.
+            2. **Python 3.11+ when the agent runs asynchronously** — which the
+               CopilotKit runtime always does. Below 3.11 the run config does
+               not propagate into asyncio tasks, so ``interrupt()`` cannot read
+               it. This constrains every async ``interrupt()``, not just this
+               flag; the middleware raises ``CopilotKitMisuseError`` instead of
+               LangGraph's opaque ``Called get_config outside of a runnable
+               context``.
+            3. **The client must resume explicitly.** The default frontend-tool
+               loop fires a plain follow-up run with no resume command, which an
+               interrupted thread ignores. Mount a client handler that reads
+               ``__copilotkit_frontend_tool_calls__`` off the interrupt and
+               resumes with
+               ``{"tool_results": [{"toolCallId": ..., "content": ...}, ...]}``.
+            4. **All calls share one interrupt.** Batching is required — a
+               resume cannot address multiple pending interrupts without
+               interrupt ids (ag-ui-protocol/ag-ui#2178).
     """
 
     state_schema = StateSchema
@@ -259,6 +390,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         *,
         expose_state: Union[bool, Iterable[str]] = False,
         a2ui_params: "Optional[A2UIToolParams]" = None,
+        interrupt_frontend_tools: bool = False,
     ):
         super().__init__()
         if isinstance(expose_state, bool):
@@ -270,6 +402,10 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         # bleed into the middleware. ``model`` + the registered catalog are
         # layered in at build time; everything here is host-owned and wins.
         self._a2ui_params: dict = dict(a2ui_params or {})
+        # Off by default: interrupt-based frontend tools need a checkpointer and
+        # a client that resumes explicitly, so flipping this on for everyone
+        # would break every deployment without one.
+        self._interrupt_frontend_tools = interrupt_frontend_tools
 
     @property
     def name(self) -> str:
@@ -664,9 +800,6 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         #    result comes in as a separate message with a different ID, so both end
         #    up in the list. Keep the real (non-interrupted) one; if multiple real
         #    ones exist, keep the last.
-        _INTERRUPTED_PAT = re.compile(
-            r"^Tool call '.+' with id '.+' was interrupted before completion\.$"
-        )
         # Group ToolMessages by tool_call_id, preserving position
         tc_groups: dict[str, list] = {}
         for i, msg in enumerate(messages):
@@ -1054,22 +1187,213 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         # Delegate to sync implementation
         return self.before_agent(state, runtime)
 
-    # Intercept frontend tool calls after model returns, before ToolNode executes
+    @classmethod
+    def _frontend_tool_names(
+        cls,
+        state: StateSchema,
+        runtime: Runtime[Any],
+    ) -> set:
+        """Names of the frontend tools the client forwarded for this run."""
+        frontend_tools = cls._get_copilotkit_context(
+            state,
+            getattr(runtime, "context", None),
+        ).get("actions", [])
+        return {
+            t.get("function", {}).get("name") or t.get("name") for t in frontend_tools
+        }
+
+    @staticmethod
+    def _check_interrupt_preconditions() -> None:
+        """Fail early, and actionably, on the two ways interrupt mode cannot work.
+
+        LangGraph reports both of these late or cryptically:
+
+        * **Python 3.11+ when the agent runs async.** On 3.10 the run config does
+          not propagate into asyncio tasks, so ``interrupt()`` cannot read it and
+          dies with ``Called get_config outside of a runnable context``. This
+          applies to any ``interrupt()`` from an async node, not just this flag.
+        * **A checkpointer.** A paused run cannot be resumed without one, and
+          LangGraph only notices at resume time — by which point the turn is
+          lost and the message points nowhere near the flag that caused it.
+        """
+        try:
+            from langgraph.config import get_config
+
+            configurable = (get_config() or {}).get("configurable", {}) or {}
+        except RuntimeError as error:
+            if sys.version_info < (3, 11) and _in_async_task():
+                raise CopilotKitMisuseError(
+                    "CopilotKitMiddleware(interrupt_frontend_tools=True) needs "
+                    "Python 3.11+ when the agent runs asynchronously: on 3.10 the "
+                    "run config does not propagate into asyncio tasks, so "
+                    "LangGraph's interrupt() cannot read it. Upgrade to 3.11+, or "
+                    "leave the flag off to use the default frontend-tool flow."
+                ) from error
+            # Not inside a runnable context at all (e.g. a direct unit-test
+            # call) — nothing to validate.
+            return
+        except Exception:  # noqa: BLE001 - never block a run on a probe failure
+            return
+
+        # LangGraph always writes this key into a task's config; the value is
+        # None when the graph was compiled without a checkpointer. A missing key
+        # means we are not inside a Pregel task at all, so there is nothing to
+        # check.
+        if configurable.get("__pregel_checkpointer", "missing") is None:
+            raise CopilotKitMisuseError(
+                "CopilotKitMiddleware(interrupt_frontend_tools=True) requires a "
+                "checkpointer: the run pauses on interrupt() and has to be "
+                "restored when the client resumes. Compile the agent with one, "
+                "e.g. create_agent(..., checkpointer=InMemorySaver()). Without it "
+                "LangGraph fails later with 'Cannot use Command(resume=...) "
+                "without checkpointer'."
+            )
+
+    # Intercept frontend tool calls after model returns, before ToolNode executes.
+    #
+    # NOTE: this hook must stay free of side effects. In interrupt mode
+    # ``interrupt()`` raises out of it, LangGraph discards every write from the
+    # interrupting task, and the whole node re-runs from the top on resume —
+    # so anything that mutates module state here would fire twice.
     def after_model(
         self,
         state: StateSchema,
         runtime: Runtime[Any],
     ) -> dict[str, Any] | None:
-        frontend_tools = self._get_copilotkit_context(
-            state,
-            getattr(runtime, "context", None),
-        ).get("actions", [])
-        if not frontend_tools:
+        if self._interrupt_frontend_tools:
+            return self._await_frontend_tool_calls(state, runtime)
+        return self._strip_frontend_tool_calls(state, runtime)
+
+    def _await_frontend_tool_calls(
+        self,
+        state: StateSchema,
+        runtime: Runtime[Any],
+    ) -> dict[str, Any] | None:
+        """Pause the turn on one batched interrupt until the client answers.
+
+        Unlike the default path this leaves the AIMessage untouched and appends
+        a real ToolMessage per frontend call, so the model resumes the same turn
+        with the results in hand and the persisted history reads naturally.
+        Keeping the tool_calls in place is also what keeps each new ToolMessage
+        paired with a matching id, so ``_fix_messages_for_bedrock`` does not
+        strip them as orphans.
+        """
+        frontend_tool_names = self._frontend_tool_names(state, runtime)
+        if not frontend_tool_names:
             return None
 
-        frontend_tool_names = {
-            t.get("function", {}).get("name") or t.get("name") for t in frontend_tools
+        messages = state.get("messages", [])
+
+        # Scan backwards rather than checking messages[-1]: on resume this node
+        # re-runs from the top, and a checkpointer that applies
+        # patch_orphan_tool_calls (see _fix_messages_for_bedrock) will have
+        # inserted placeholder ToolMessages after the AIMessage. Looking only at
+        # the last message would miss it, skip the interrupt, and leave the
+        # resume value unconsumed.
+        ai_index = next(
+            (
+                i
+                for i in range(len(messages) - 1, -1, -1)
+                if isinstance(messages[i], AIMessage)
+            ),
+            None,
+        )
+        if ai_index is None:
+            return None
+
+        tool_calls = getattr(messages[ai_index], "tool_calls", None) or []
+        if not tool_calls:
+            return None
+
+        # A call counts as answered only by a *real* result. The placeholders
+        # above say "was interrupted before completion"; accepting one as an
+        # answer would hand the model that sentence as the tool's output.
+        answered_ids = {
+            getattr(msg, "tool_call_id", None)
+            for msg in messages[ai_index + 1 :]
+            if isinstance(msg, ToolMessage)
+            and not (
+                isinstance(msg.content, str) and _INTERRUPTED_PAT.match(msg.content)
+            )
         }
+
+        frontend_calls = [
+            call
+            for call in tool_calls
+            if call.get("name") in frontend_tool_names
+            and call.get("id")
+            and call.get("id") not in answered_ids
+        ]
+        # Also makes the hook idempotent: once results are in state, re-entering
+        # this node finds nothing outstanding instead of interrupting again.
+        if not frontend_calls:
+            return None
+
+        self._check_interrupt_preconditions()
+
+        # One interrupt for the whole batch. A resume carries a single value and
+        # cannot address several pending interrupts without their ids
+        # (ag-ui-protocol/ag-ui#2178), so one interrupt per call would deadlock
+        # any turn where the model called more than one frontend tool.
+        #
+        # Not wrapped in try/except: interrupt() signals the pause by raising,
+        # and swallowing that would turn it into a silent no-op.
+        resumed = interrupt(
+            {
+                _FE_INTERRUPT_KEY: [
+                    {
+                        "id": call["id"],
+                        "name": call.get("name"),
+                        "args": call.get("args") or {},
+                    }
+                    for call in frontend_calls
+                ]
+            }
+        )
+
+        results = _parse_frontend_tool_results(resumed)
+        if results is _UNRECOGNIZED_RESUME:
+            raise CopilotKitMisuseError(
+                "CopilotKitMiddleware(interrupt_frontend_tools=True) was resumed "
+                "with a payload it does not recognise. Expected "
+                '{"tool_results": [{"toolCallId": ..., "content": ...}, ...]} or a '
+                f"bare list of those, got {type(resumed).__name__}. A resume "
+                "carries one value and the first pending interrupt consumes it, "
+                "so this usually means another interrupt's answer arrived here."
+            )
+
+        # One ToolMessage per call, in the order the model emitted them. Calls
+        # the client did not answer still get one, so no tool_call is left
+        # unpaired — an unanswered tool call is rejected outright by Bedrock and
+        # confuses every other provider.
+        #
+        # Messages ONLY. No "jump_to": create_agent's model->tools edge already
+        # routes correctly — it sends just the unanswered (backend) calls to
+        # ToolNode, and re-enters the model when an AIMessage has tool calls but
+        # none pending. And no "copilotkit" key: that channel has no reducer, so
+        # writing it would replace the whole dict and wipe "actions", which this
+        # hook re-reads on resume.
+        return {
+            "messages": [
+                ToolMessage(
+                    content=results.get(call["id"], _MISSING_TOOL_RESULT_CONTENT),
+                    tool_call_id=call["id"],
+                    name=call.get("name"),
+                    id=f"copilotkit-fe-tool-result-{call['id']}",
+                )
+                for call in frontend_calls
+            ]
+        }
+
+    def _strip_frontend_tool_calls(
+        self,
+        state: StateSchema,
+        runtime: Runtime[Any],
+    ) -> dict[str, Any] | None:
+        """Default path: park frontend calls until the next run answers them."""
+        frontend_tool_names = self._frontend_tool_names(state, runtime)
+        if not frontend_tool_names:
+            return None
 
         # Find last AI message with tool calls
         messages = state.get("messages", [])

--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -118,8 +118,7 @@ def _parse_frontend_tool_results(payload: Any) -> Any:
     container at all. That case is worth failing loudly on: a single
     ``Command(resume=...)`` carries one value and the first pending interrupt
     consumes it, so another interrupt's answer (say ``{"approved": True}``) can
-    land here. Turning that into "no tool ran" would leave the developer
-    debugging a model apology instead of a wiring mistake. A well-formed but
+    land here. A well-formed but
     empty container (``{"tool_results": []}``) is *not* unrecognised — that is a
     client legitimately answering nothing, and every call gets a placeholder.
     """
@@ -344,42 +343,31 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             model (the host cannot supply the live, header-hooked model), and
             folds the registered catalog id + component schema into the params
             unless the host already set them — so host values win.
-        interrupt_frontend_tools: Opt in to awaiting frontend tool results
-            *within* the same agent turn, using LangGraph's native
-            ``interrupt()`` instead of the default strip-and-restore.
+        interrupt_frontend_tools: Await frontend tool results *in the same
+            turn* via LangGraph's ``interrupt()``, instead of the default
+            strip-and-restore.
 
-            - ``False`` (default) — frontend tool calls are stripped off the
-              ``AIMessage`` in ``after_model`` and restored in ``after_agent``;
-              the real result only lands on the next run. The agent never awaits
-              it in-run.
-            - ``True`` — every frontend tool call in a turn is batched into a
-              single ``interrupt()``. The graph pauses, the client executes the
-              tools and resumes, and one real ``ToolMessage`` per call is
-              appended — so the model continues the same turn with the results
-              in hand, in the natural ``AIMessage`` → ``ToolMessage`` order.
+            ``False`` (default) strips the calls off the ``AIMessage`` in
+            ``after_model`` and restores them in ``after_agent``, so the result
+            only lands on the next run, never in-run. ``True`` batches a turn's
+            calls into one ``interrupt()``: the graph pauses, the client runs
+            the tools and resumes, and one real ``ToolMessage`` per call is
+            appended, so the model finishes the turn with the results in hand,
+            in natural ``AIMessage`` → ``ToolMessage`` order. ``True`` requires:
 
-            Four requirements come with ``True``:
-
-            1. **A checkpointer is mandatory.** ``interrupt()`` cannot resume
-               without one; the middleware raises ``CopilotKitMisuseError``
-               rather than letting the run fail later with LangGraph's
-               ``Cannot use Command(resume=...) without checkpointer``.
-            2. **Python 3.11+ when the agent runs asynchronously** — which the
-               CopilotKit runtime always does. Below 3.11 the run config does
-               not propagate into asyncio tasks, so ``interrupt()`` cannot read
-               it. This constrains every async ``interrupt()``, not just this
-               flag; the middleware raises ``CopilotKitMisuseError`` instead of
-               LangGraph's opaque ``Called get_config outside of a runnable
-               context``.
-            3. **The client must resume explicitly.** The default frontend-tool
-               loop fires a plain follow-up run with no resume command, which an
-               interrupted thread ignores. Mount a client handler that reads
+            1. **Python 3.11+ when async**, which the runtime always is: below
+               3.11 the run config does not reach asyncio tasks, so *any* async
+               ``interrupt()`` cannot read it. Raises ``CopilotKitMisuseError``,
+               not ``Called get_config outside of a runnable context``.
+            2. **An explicit client resume** — the default frontend-tool loop
+               fires a follow-up run with no resume command, which an
+               interrupted thread ignores. Mount a handler that reads
                ``__copilotkit_frontend_tool_calls__`` off the interrupt and
-               resumes with
-               ``{"tool_results": [{"toolCallId": ..., "content": ...}, ...]}``.
-            4. **All calls share one interrupt.** Batching is required — a
-               resume cannot address multiple pending interrupts without
-               interrupt ids (ag-ui-protocol/ag-ui#2178).
+               resumes with ``{"tool_results": [{"toolCallId": ...,
+               "content": ...}, ...]}``.
+            3. **One interrupt per turn** — a resume cannot address multiple
+               pending interrupts without interrupt ids
+               (ag-ui-protocol/ag-ui#2178), so batching is mandatory.
     """
 
     state_schema = StateSchema
@@ -402,9 +390,6 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         # bleed into the middleware. ``model`` + the registered catalog are
         # layered in at build time; everything here is host-owned and wins.
         self._a2ui_params: dict = dict(a2ui_params or {})
-        # Off by default: interrupt-based frontend tools need a checkpointer and
-        # a client that resumes explicitly, so flipping this on for everyone
-        # would break every deployment without one.
         self._interrupt_frontend_tools = interrupt_frontend_tools
 
     @property
@@ -1204,22 +1189,17 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
 
     @staticmethod
     def _check_interrupt_preconditions() -> None:
-        """Fail early, and actionably, on the two ways interrupt mode cannot work.
+        """Fail early, and actionably, when interrupt mode cannot work.
 
-        LangGraph reports both of these late or cryptically:
-
-        * **Python 3.11+ when the agent runs async.** On 3.10 the run config does
-          not propagate into asyncio tasks, so ``interrupt()`` cannot read it and
-          dies with ``Called get_config outside of a runnable context``. This
-          applies to any ``interrupt()`` from an async node, not just this flag.
-        * **A checkpointer.** A paused run cannot be resumed without one, and
-          LangGraph only notices at resume time — by which point the turn is
-          lost and the message points nowhere near the flag that caused it.
+        On Python 3.10 the run config does not propagate into asyncio tasks, so
+        ``interrupt()`` cannot read it and dies with LangGraph's opaque ``Called
+        get_config outside of a runnable context``. This applies to any
+        ``interrupt()`` from an async node, not just this flag.
         """
         try:
             from langgraph.config import get_config
 
-            configurable = (get_config() or {}).get("configurable", {}) or {}
+            get_config()
         except RuntimeError as error:
             if sys.version_info < (3, 11) and _in_async_task():
                 raise CopilotKitMisuseError(
@@ -1234,20 +1214,6 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             return
         except Exception:  # noqa: BLE001 - never block a run on a probe failure
             return
-
-        # LangGraph always writes this key into a task's config; the value is
-        # None when the graph was compiled without a checkpointer. A missing key
-        # means we are not inside a Pregel task at all, so there is nothing to
-        # check.
-        if configurable.get("__pregel_checkpointer", "missing") is None:
-            raise CopilotKitMisuseError(
-                "CopilotKitMiddleware(interrupt_frontend_tools=True) requires a "
-                "checkpointer: the run pauses on interrupt() and has to be "
-                "restored when the client resumes. Compile the agent with one, "
-                "e.g. create_agent(..., checkpointer=InMemorySaver()). Without it "
-                "LangGraph fails later with 'Cannot use Command(resume=...) "
-                "without checkpointer'."
-            )
 
     # Intercept frontend tool calls after model returns, before ToolNode executes.
     #

--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -64,36 +64,29 @@ _a2ui_tools_by_thread: dict[str, Any] = {}
 _DEFAULT_THREAD_KEY = "__copilotkit_a2ui_default__"
 _FRONTEND_TOOL_RESULT_CONTENT = json.dumps({"status": "forwarded_to_frontend"})
 
-# Placeholder LangGraph's ``patch_orphan_tool_calls`` writes for a tool call that
-# was still pending when a checkpoint was saved. Hoisted to module scope so both
-# ``_fix_messages_for_bedrock`` and the interrupt path can match it without
-# recompiling the pattern on every call.
+# Placeholder LangGraph's ``patch_orphan_tool_calls`` writes for a tool call
+# still pending when a checkpoint was saved.
 _INTERRUPTED_PAT = re.compile(
     r"^Tool call '.+' with id '.+' was interrupted before completion\.$"
 )
 
-# Key carrying the batched frontend tool calls in the interrupt payload emitted
-# when ``interrupt_frontend_tools`` is on. Namespaced so a client can tell this
-# apart from a human-facing interrupt on the same thread (e.g. via
-# ``useInterrupt({ enabled })``). Deliberately NOT ``__copilotkit_interrupt_value__``
-# — that envelope means "render this to the user", which this is not.
+# Frontend tool calls batched into the interrupt payload. Namespaced so a client
+# can tell this from a human-facing interrupt (``useInterrupt({ enabled })``);
+# not ``__copilotkit_interrupt_value__``, which means "render this to the user".
 _FE_INTERRUPT_KEY = "__copilotkit_frontend_tool_calls__"
 
-# Content used when the client resumed without answering a frontend tool call.
-# Every call still gets a ToolMessage so no tool_call is left unpaired.
+# Used when the client resumed without answering a call; every call needs a pair.
 _MISSING_TOOL_RESULT_CONTENT = json.dumps({"ok": False, "error": "missing_tool_result"})
 
-# Sentinel distinguishing "resumed with no results" from "this resume payload
-# was never meant for us" (e.g. a human interrupt's answer was consumed first).
+# Distinguishes "resumed with no results" from "this payload was not for us".
 _UNRECOGNIZED_RESUME = object()
 
 
 def _coerce_result(raw: dict) -> "tuple[str, str]":
     """Normalise one client tool result into ``(tool_call_id, content)``.
 
-    Accepts the id under ``toolCallId`` (the wire casing), ``tool_call_id`` or
-    ``id``, and the payload under ``content`` or ``result``. Non-string content
-    is JSON-encoded, since ``ToolMessage.content`` has to be a string.
+    Accepts the id as ``toolCallId``/``tool_call_id``/``id`` and the payload as
+    ``content``/``result``. Non-string content is JSON-encoded.
     """
     tool_call_id = raw.get("toolCallId") or raw.get("tool_call_id") or raw.get("id")
     content = raw.get("content")
@@ -107,18 +100,11 @@ def _coerce_result(raw: dict) -> "tuple[str, str]":
 def _parse_frontend_tool_results(payload: Any) -> Any:
     """Normalise a resume payload into ``{tool_call_id: content}``.
 
-    The wire shape is ``forwardedProps.command.resume = {"tool_results": [...]}``,
-    which ``ag_ui_langgraph`` passes to ``Command(resume=...)`` verbatim. It
-    JSON-decodes string payloads first, so the ``str`` branch here only matters
-    for callers driving the graph directly. A bare list is accepted too.
-
-    Returns ``_UNRECOGNIZED_RESUME`` when the payload is not a tool-result
-    container at all. That case is worth failing loudly on: a single
-    ``Command(resume=...)`` carries one value and the first pending interrupt
-    consumes it, so another interrupt's answer (say ``{"approved": True}``) can
-    land here. A well-formed but
-    empty container (``{"tool_results": []}``) is *not* unrecognised — that is a
-    client legitimately answering nothing, and every call gets a placeholder.
+    The wire shape is ``forwardedProps.command.resume = {"tool_results": [...]}``;
+    a bare list is accepted too. Returns ``_UNRECOGNIZED_RESUME`` when the
+    payload is not a tool-result container at all, which is worth failing loudly
+    on. An empty container is *not* unrecognised — that is a client legitimately
+    answering nothing.
     """
     if isinstance(payload, str):
         try:
@@ -1173,12 +1159,9 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             t.get("function", {}).get("name") or t.get("name") for t in frontend_tools
         }
 
-    # Intercept frontend tool calls after model returns, before ToolNode executes.
-    #
-    # NOTE: this hook must stay free of side effects. In interrupt mode
-    # ``interrupt()`` raises out of it, LangGraph discards every write from the
-    # interrupting task, and the whole node re-runs from the top on resume —
-    # so anything that mutates module state here would fire twice.
+    # Intercept frontend tool calls after the model returns, before ToolNode runs.
+    # Must stay side-effect free: in interrupt mode ``interrupt()`` raises out of
+    # here, so the node re-runs from the top on resume.
     def after_model(
         self,
         state: StateSchema,
@@ -1195,12 +1178,10 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
     ) -> dict[str, Any] | None:
         """Pause the turn on one batched interrupt until the client answers.
 
-        Unlike the default path this leaves the AIMessage untouched and appends
-        a real ToolMessage per frontend call, so the model resumes the same turn
-        with the results in hand and the persisted history reads naturally.
-        Keeping the tool_calls in place is also what keeps each new ToolMessage
-        paired with a matching id, so ``_fix_messages_for_bedrock`` does not
-        strip them as orphans.
+        Leaves the AIMessage untouched and appends a real ToolMessage per call,
+        so the model resumes the same turn with the results in hand. Keeping the
+        tool_calls in place is what keeps each ToolMessage paired with an id, so
+        ``_fix_messages_for_bedrock`` does not strip them as orphans.
         """
         frontend_tool_names = self._frontend_tool_names(state, runtime)
         if not frontend_tool_names:
@@ -1208,12 +1189,9 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
 
         messages = state.get("messages", [])
 
-        # Scan backwards rather than checking messages[-1]: on resume this node
-        # re-runs from the top, and a checkpointer that applies
-        # patch_orphan_tool_calls (see _fix_messages_for_bedrock) will have
-        # inserted placeholder ToolMessages after the AIMessage. Looking only at
-        # the last message would miss it, skip the interrupt, and leave the
-        # resume value unconsumed.
+        # Scan backwards, not messages[-1]: on resume a checkpointer that ran
+        # patch_orphan_tool_calls has inserted placeholder ToolMessages after the
+        # AIMessage, which would hide it and skip the interrupt.
         ai_index = next(
             (
                 i
@@ -1229,9 +1207,8 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         if not tool_calls:
             return None
 
-        # A call counts as answered only by a *real* result. The placeholders
-        # above say "was interrupted before completion"; accepting one as an
-        # answer would hand the model that sentence as the tool's output.
+        # Only a *real* result counts as answered: the placeholders say "was
+        # interrupted before completion", which is not a tool output.
         answered_ids = {
             getattr(msg, "tool_call_id", None)
             for msg in messages[ai_index + 1 :]
@@ -1248,18 +1225,13 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             and call.get("id")
             and call.get("id") not in answered_ids
         ]
-        # Also makes the hook idempotent: once results are in state, re-entering
-        # this node finds nothing outstanding instead of interrupting again.
+        # Idempotent: once results are in state there is nothing outstanding.
         if not frontend_calls:
             return None
 
-        # One interrupt for the whole batch. A resume carries a single value and
-        # cannot address several pending interrupts without their ids
-        # (ag-ui-protocol/ag-ui#2178), so one interrupt per call would deadlock
-        # any turn where the model called more than one frontend tool.
-        #
-        # Not wrapped in try/except: interrupt() signals the pause by raising,
-        # and swallowing that would turn it into a silent no-op.
+        # One interrupt for the whole batch: a resume cannot address several
+        # pending interrupts without ids (ag-ui-protocol/ag-ui#2178). Not wrapped
+        # in try/except — interrupt() signals the pause by raising.
         resumed = interrupt(
             {
                 _FE_INTERRUPT_KEY: [
@@ -1279,22 +1251,15 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
                 "CopilotKitMiddleware(interrupt_frontend_tools=True) was resumed "
                 "with a payload it does not recognise. Expected "
                 '{"tool_results": [{"toolCallId": ..., "content": ...}, ...]} or a '
-                f"bare list of those, got {type(resumed).__name__}. A resume "
-                "carries one value and the first pending interrupt consumes it, "
-                "so this usually means another interrupt's answer arrived here."
+                f"bare list of those, got {type(resumed).__name__}."
             )
 
-        # One ToolMessage per call, in the order the model emitted them. Calls
-        # the client did not answer still get one, so no tool_call is left
-        # unpaired — an unanswered tool call is rejected outright by Bedrock and
-        # confuses every other provider.
+        # Unanswered calls still get a ToolMessage: an unpaired tool_call is
+        # rejected by Bedrock and confuses other providers.
         #
-        # Messages ONLY. No "jump_to": create_agent's model->tools edge already
-        # routes correctly — it sends just the unanswered (backend) calls to
-        # ToolNode, and re-enters the model when an AIMessage has tool calls but
-        # none pending. And no "copilotkit" key: that channel has no reducer, so
-        # writing it would replace the whole dict and wipe "actions", which this
-        # hook re-reads on resume.
+        # No "jump_to" — create_agent's model->tools edge already routes
+        # correctly. No "copilotkit" key — that channel has no reducer, so
+        # writing it would wipe "actions", which this hook re-reads on resume.
         return {
             "messages": [
                 ToolMessage(

--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -75,7 +75,8 @@ _INTERRUPTED_PAT = re.compile(
 # not ``__copilotkit_interrupt_value__``, which means "render this to the user".
 _FE_INTERRUPT_KEY = "__copilotkit_frontend_tool_calls__"
 
-# Used when the client resumed without answering a call; every call needs a pair.
+# Used when the client resumed without answering a call: an unpaired tool_call is
+# rejected by Bedrock and confuses other providers.
 _MISSING_TOOL_RESULT_CONTENT = json.dumps({"ok": False, "error": "missing_tool_result"})
 
 # Distinguishes "resumed with no results" from "this payload was not for us".
@@ -1254,9 +1255,6 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
                 f"bare list of those, got {type(resumed).__name__}."
             )
 
-        # Unanswered calls still get a ToolMessage: an unpaired tool_call is
-        # rejected by Bedrock and confuses other providers.
-        #
         # No "jump_to" — create_agent's model->tools edge already routes
         # correctly. No "copilotkit" key — that channel has no reducer, so
         # writing it would wipe "actions", which this hook re-reads on resume.

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -2272,10 +2272,9 @@ def _interrupt_state(tool_calls, *, extra_messages=(), actions=(_FE_ACTION,)):
 def _run_after_model(state, resume, *, use_async=False):
     """Call after_model in interrupt mode with a stubbed interrupt().
 
-    Preconditions are stubbed out too: these tests drive the hook directly
-    rather than through a compiled graph, so there is no run config to check a
-    checkpointer against. The guard has its own coverage in
-    ``test_frontend_tool_interrupt.py``, where real graphs are involved.
+    The precondition probe is stubbed out too: these tests drive the hook
+    directly rather than through a compiled graph, so there is no run config
+    for it to read.
     """
     middleware = CopilotKitMiddleware(interrupt_frontend_tools=True)
     with (

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import asyncio
 import json
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from ag_ui.core import RunAgentInput, UserMessage
@@ -51,8 +51,10 @@ from langgraph.graph import StateGraph
 
 from copilotkit.copilotkit_lg_middleware import (
     CopilotKitMiddleware,
+    _FRONTEND_TOOL_RESULT_CONTENT,
     _extract_forwarded_headers_from_config,
 )
+from copilotkit.exc import CopilotKitMisuseError
 from copilotkit.header_propagation import get_forwarded_headers, set_forwarded_headers
 from copilotkit.langgraph_agui_agent import LangGraphAGUIAgent
 
@@ -2236,3 +2238,366 @@ class TestAutoA2UI:
         names = [getattr(t, "name", None) or t.get("name") for t in seen.tools]
         # Only the agent's own tool — no second generate_a2ui appended.
         assert names.count("generate_a2ui") == 1
+
+
+# ---------------------------------------------------------------------------
+# interrupt_frontend_tools — opt-in: await frontend tool results in-run via
+# LangGraph's interrupt() instead of the default strip-and-restore
+# ---------------------------------------------------------------------------
+#
+# Contract: with the flag on, every frontend call in a turn is batched into a
+# single interrupt(); the resumed results become real ToolMessages appended to
+# the turn; the AIMessage is left untouched; and the state update carries
+# messages and nothing else. With the flag off nothing changes at all.
+
+_FE_ACTION = {"function": {"name": "navigate"}}
+_FE_CALL = {"id": "fe-1", "name": "navigate", "args": {"path": "/x"}}
+_FE_CALL_2 = {"id": "fe-2", "name": "navigate", "args": {"path": "/y"}}
+_BE_CALL = {"id": "be-1", "name": "backend_search", "args": {"q": "hi"}}
+_INTERRUPT_TARGET = "copilotkit.copilotkit_lg_middleware.interrupt"
+
+
+def _interrupt_state(tool_calls, *, extra_messages=(), actions=(_FE_ACTION,)):
+    """State whose last AIMessage carries ``tool_calls``."""
+    return {
+        "messages": [
+            HumanMessage("hi"),
+            AIMessage(content="", tool_calls=list(tool_calls), id="ai-1"),
+            *extra_messages,
+        ],
+        "copilotkit": {"actions": list(actions)},
+    }
+
+
+def _run_after_model(state, resume, *, use_async=False):
+    """Call after_model in interrupt mode with a stubbed interrupt().
+
+    Preconditions are stubbed out too: these tests drive the hook directly
+    rather than through a compiled graph, so there is no run config to check a
+    checkpointer against. The guard has its own coverage in
+    ``test_frontend_tool_interrupt.py``, where real graphs are involved.
+    """
+    middleware = CopilotKitMiddleware(interrupt_frontend_tools=True)
+    with (
+        patch(_INTERRUPT_TARGET) as fake_interrupt,
+        patch.object(CopilotKitMiddleware, "_check_interrupt_preconditions"),
+    ):
+        fake_interrupt.return_value = resume
+        runtime = MagicMock(name="runtime")
+        runtime.context = None
+        if use_async:
+            result = asyncio.run(middleware.aafter_model(state, runtime))
+        else:
+            result = middleware.after_model(state, runtime)
+    return result, fake_interrupt
+
+
+# --- flag off: the default path is untouched -------------------------------
+
+
+def test_default_path_never_interrupts_and_still_strips():
+    state = _interrupt_state([_BE_CALL, _FE_CALL])
+
+    with patch(_INTERRUPT_TARGET) as fake_interrupt:
+        result = CopilotKitMiddleware().after_model(state, MagicMock(name="runtime"))
+
+    fake_interrupt.assert_not_called()
+    copilotkit = result["copilotkit"]
+    assert [c["id"] for c in copilotkit["intercepted_tool_calls"]] == ["fe-1"]
+    assert [c["id"] for c in copilotkit["original_tool_calls"]] == ["be-1", "fe-1"]
+    ai = result["messages"][-1]
+    assert [tc["id"] for tc in ai.tool_calls] == ["be-1"]
+    # No jump_to on the default path — the routing edge decides on its own.
+    assert "jump_to" not in result
+
+
+# --- flag on: nothing to await ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        pytest.param(
+            {"messages": [HumanMessage("hi")], "copilotkit": {"actions": []}},
+            id="no-frontend-actions",
+        ),
+        pytest.param(
+            {"messages": [], "copilotkit": {"actions": [_FE_ACTION]}},
+            id="no-messages",
+        ),
+        pytest.param(
+            {
+                "messages": [HumanMessage("hi")],
+                "copilotkit": {"actions": [_FE_ACTION]},
+            },
+            id="no-ai-message",
+        ),
+        pytest.param(_interrupt_state([]), id="ai-message-without-tool-calls"),
+        pytest.param(_interrupt_state([_BE_CALL]), id="backend-calls-only"),
+    ],
+)
+def test_interrupt_mode_no_ops_when_nothing_to_await(state):
+    result, fake_interrupt = _run_after_model(state, None)
+
+    assert result is None
+    fake_interrupt.assert_not_called()
+
+
+# --- flag on: core behaviour -----------------------------------------------
+
+
+@pytest.mark.parametrize("use_async", [False, True])
+def test_single_frontend_call_interrupts_and_returns_real_result(use_async):
+    state = _interrupt_state([_FE_CALL])
+    resume = {"tool_results": [{"toolCallId": "fe-1", "content": '{"ok": true}'}]}
+
+    result, fake_interrupt = _run_after_model(state, resume, use_async=use_async)
+
+    fake_interrupt.assert_called_once_with(
+        {
+            "__copilotkit_frontend_tool_calls__": [
+                {"id": "fe-1", "name": "navigate", "args": {"path": "/x"}}
+            ]
+        }
+    )
+    (message,) = result["messages"]
+    assert isinstance(message, ToolMessage)
+    assert message.tool_call_id == "fe-1"
+    assert message.content == '{"ok": true}'
+    # Messages only: no jump_to, and crucially no "copilotkit" — that channel
+    # has no reducer, so writing it would wipe "actions" for the resumed run.
+    assert set(result) == {"messages"}
+
+
+def test_every_frontend_call_shares_one_interrupt():
+    """Batching is mandatory — a resume cannot address several pending
+    interrupts without their ids (ag-ui-protocol/ag-ui#2178)."""
+    state = _interrupt_state([_FE_CALL, _FE_CALL_2])
+    resume = {
+        "tool_results": [
+            {"toolCallId": "fe-1", "content": "one"},
+            {"toolCallId": "fe-2", "content": "two"},
+        ]
+    }
+
+    result, fake_interrupt = _run_after_model(state, resume)
+
+    assert fake_interrupt.call_count == 1
+    payload = fake_interrupt.call_args.args[0]
+    assert [c["id"] for c in payload["__copilotkit_frontend_tool_calls__"]] == [
+        "fe-1",
+        "fe-2",
+    ]
+    assert [m.content for m in result["messages"]] == ["one", "two"]
+
+
+def test_mixed_turn_answers_only_frontend_calls_and_keeps_ai_message_intact():
+    state = _interrupt_state([_BE_CALL, _FE_CALL])
+    resume = {"tool_results": [{"toolCallId": "fe-1", "content": "done"}]}
+
+    result, _ = _run_after_model(state, resume)
+
+    assert [m.tool_call_id for m in result["messages"]] == ["fe-1"]
+    assert set(result) == {"messages"}
+    # The AIMessage is never rewritten, so the backend call is still pending and
+    # the routing edge will send it — and only it — to the ToolNode.
+    ai = state["messages"][1]
+    assert [tc["id"] for tc in ai.tool_calls] == ["be-1", "fe-1"]
+
+
+def test_flat_action_descriptors_are_matched():
+    state = _interrupt_state([_FE_CALL], actions=({"name": "navigate"},))
+
+    result, fake_interrupt = _run_after_model(
+        state, {"tool_results": [{"toolCallId": "fe-1", "content": "ok"}]}
+    )
+
+    fake_interrupt.assert_called_once()
+    assert [m.content for m in result["messages"]] == ["ok"]
+
+
+# --- flag on: re-entry after the node re-runs -------------------------------
+
+
+def test_placeholder_tool_message_does_not_count_as_an_answer():
+    """A checkpointer that runs patch_orphan_tool_calls injects a placeholder
+    for the paused call. Treating it as an answer would skip the interrupt and
+    hand the model "was interrupted before completion" as the tool's output."""
+    placeholder = ToolMessage(
+        content="Tool call 'navigate' with id 'fe-1' was interrupted before completion.",
+        tool_call_id="fe-1",
+    )
+    state = _interrupt_state([_FE_CALL], extra_messages=(placeholder,))
+
+    result, fake_interrupt = _run_after_model(
+        state, {"tool_results": [{"toolCallId": "fe-1", "content": "real"}]}
+    )
+
+    fake_interrupt.assert_called_once()
+    assert [m.content for m in result["messages"]] == ["real"]
+
+
+def test_real_result_already_in_state_is_idempotent():
+    answered = ToolMessage(content='{"ok": true}', tool_call_id="fe-1")
+    state = _interrupt_state([_FE_CALL], extra_messages=(answered,))
+
+    result, fake_interrupt = _run_after_model(state, None)
+
+    assert result is None
+    fake_interrupt.assert_not_called()
+
+
+# --- flag on: resume payload handling --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "resume,expected",
+    [
+        pytest.param(
+            {"tool_results": [{"toolCallId": "fe-1", "content": "a"}]},
+            "a",
+            id="wire-casing",
+        ),
+        pytest.param(
+            {"tool_results": [{"tool_call_id": "fe-1", "content": "a"}]},
+            "a",
+            id="snake-case-id",
+        ),
+        pytest.param(
+            {"tool_results": [{"id": "fe-1", "content": "a"}]}, "a", id="bare-id"
+        ),
+        pytest.param(
+            {"tool_results": [{"toolCallId": "fe-1", "result": "a"}]},
+            "a",
+            id="result-alias",
+        ),
+        pytest.param([{"toolCallId": "fe-1", "content": "a"}], "a", id="bare-list"),
+        pytest.param(
+            '{"tool_results": [{"toolCallId": "fe-1", "content": "a"}]}',
+            "a",
+            id="json-string",
+        ),
+        pytest.param(
+            {"tool_results": [{"toolCallId": "fe-1", "content": {"ok": True}}]},
+            '{"ok": true}',
+            id="dict-content-is-json-encoded",
+        ),
+        pytest.param(
+            {
+                "tool_results": [
+                    {"toolCallId": "fe-1", "content": "first"},
+                    {"toolCallId": "fe-1", "content": "second"},
+                ]
+            },
+            "second",
+            id="duplicate-ids-last-wins",
+        ),
+        pytest.param(
+            {
+                "tool_results": [
+                    {"toolCallId": "never-asked", "content": "junk"},
+                    {"toolCallId": "fe-1", "content": "a"},
+                ]
+            },
+            "a",
+            id="unknown-ids-dropped",
+        ),
+    ],
+)
+def test_resume_payload_shapes(resume, expected):
+    result, _ = _run_after_model(_interrupt_state([_FE_CALL]), resume)
+
+    (message,) = result["messages"]
+    assert message.tool_call_id == "fe-1"
+    assert message.content == expected
+
+
+def test_unanswered_call_still_gets_a_paired_tool_message():
+    """Every tool_call must end up paired — Bedrock rejects an unanswered one
+    outright, and other providers handle it inconsistently."""
+    state = _interrupt_state([_FE_CALL, _FE_CALL_2])
+    resume = {"tool_results": [{"toolCallId": "fe-1", "content": "only-one"}]}
+
+    result, _ = _run_after_model(state, resume)
+
+    assert [m.tool_call_id for m in result["messages"]] == ["fe-1", "fe-2"]
+    assert json.loads(result["messages"][1].content) == {
+        "ok": False,
+        "error": "missing_tool_result",
+    }
+
+
+@pytest.mark.parametrize(
+    "resume", [{"tool_results": []}, []], ids=["empty-container", "empty-list"]
+)
+def test_client_answering_nothing_is_not_an_error(resume):
+    result, _ = _run_after_model(_interrupt_state([_FE_CALL]), resume)
+
+    (message,) = result["messages"]
+    assert json.loads(message.content)["error"] == "missing_tool_result"
+
+
+@pytest.mark.parametrize(
+    "resume",
+    [None, "approved", {"approved": True}, {}, 42],
+    ids=["none", "bare-string", "human-answer", "empty-dict", "number"],
+)
+def test_unrecognised_resume_payload_fails_loudly(resume):
+    """A resume carries one value and the first pending interrupt consumes it,
+    so another interrupt's answer can land here. Fabricating tool results from
+    it would leave the developer debugging a model apology."""
+    with pytest.raises(CopilotKitMisuseError, match="interrupt_frontend_tools"):
+        _run_after_model(_interrupt_state([_FE_CALL]), resume)
+
+
+# --- flag on: interaction with the rest of the middleware -------------------
+
+
+def test_after_agent_is_a_no_op_in_interrupt_mode():
+    middleware = CopilotKitMiddleware(interrupt_frontend_tools=True)
+    state = _interrupt_state([_FE_CALL])
+
+    with (
+        patch(_INTERRUPT_TARGET) as fake_interrupt,
+        patch.object(CopilotKitMiddleware, "_check_interrupt_preconditions"),
+    ):
+        fake_interrupt.return_value = {
+            "tool_results": [{"toolCallId": "fe-1", "content": "ok"}]
+        }
+        runtime = MagicMock(name="runtime")
+        runtime.context = None
+        middleware.after_model(state, runtime)
+
+    # Nothing was intercepted, so there is nothing to restore.
+    assert middleware.after_agent(state, runtime) is None
+
+
+def test_next_model_call_sees_the_real_frontend_result():
+    """The point of the feature: the model resumes the same turn with the real
+    result, not the {"status": "forwarded_to_frontend"} placeholder the default
+    path substitutes."""
+    state = _interrupt_state([_BE_CALL, _FE_CALL])
+    resume = {"tool_results": [{"toolCallId": "fe-1", "content": '{"page": "/x"}'}]}
+
+    result, _ = _run_after_model(state, resume)
+
+    messages = [
+        *state["messages"],
+        ToolMessage(content='{"hits": 1}', tool_call_id="be-1"),
+        *result["messages"],
+    ]
+    request = _make_request(
+        state={"messages": messages, "copilotkit": state["copilotkit"]},
+        messages=messages,
+    )
+    seen, _ = _run_wrap(CopilotKitMiddleware(interrupt_frontend_tools=True), request)
+
+    ai = next(m for m in seen.messages if isinstance(m, AIMessage))
+    # _fix_messages_for_bedrock leaves both calls in place because both are
+    # answered — the frontend one by a real result.
+    assert [tc["id"] for tc in ai.tool_calls] == ["be-1", "fe-1"]
+    contents = {
+        m.tool_call_id: m.content for m in seen.messages if isinstance(m, ToolMessage)
+    }
+    assert contents == {"be-1": '{"hits": 1}', "fe-1": '{"page": "/x"}'}
+    assert _FRONTEND_TOOL_RESULT_CONTENT not in contents.values()

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -2270,17 +2270,9 @@ def _interrupt_state(tool_calls, *, extra_messages=(), actions=(_FE_ACTION,)):
 
 
 def _run_after_model(state, resume, *, use_async=False):
-    """Call after_model in interrupt mode with a stubbed interrupt().
-
-    The precondition probe is stubbed out too: these tests drive the hook
-    directly rather than through a compiled graph, so there is no run config
-    for it to read.
-    """
+    """Call after_model in interrupt mode with a stubbed interrupt()."""
     middleware = CopilotKitMiddleware(interrupt_frontend_tools=True)
-    with (
-        patch(_INTERRUPT_TARGET) as fake_interrupt,
-        patch.object(CopilotKitMiddleware, "_check_interrupt_preconditions"),
-    ):
+    with patch(_INTERRUPT_TARGET) as fake_interrupt:
         fake_interrupt.return_value = resume
         runtime = MagicMock(name="runtime")
         runtime.context = None
@@ -2556,10 +2548,7 @@ def test_after_agent_is_a_no_op_in_interrupt_mode():
     middleware = CopilotKitMiddleware(interrupt_frontend_tools=True)
     state = _interrupt_state([_FE_CALL])
 
-    with (
-        patch(_INTERRUPT_TARGET) as fake_interrupt,
-        patch.object(CopilotKitMiddleware, "_check_interrupt_preconditions"),
-    ):
+    with patch(_INTERRUPT_TARGET) as fake_interrupt:
         fake_interrupt.return_value = {
             "tool_results": [{"toolCallId": "fe-1", "content": "ok"}]
         }

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -2245,10 +2245,10 @@ class TestAutoA2UI:
 # LangGraph's interrupt() instead of the default strip-and-restore
 # ---------------------------------------------------------------------------
 #
-# Contract: with the flag on, every frontend call in a turn is batched into a
-# single interrupt(); the resumed results become real ToolMessages appended to
-# the turn; the AIMessage is left untouched; and the state update carries
-# messages and nothing else. With the flag off nothing changes at all.
+# Contract: every frontend call in a turn is batched into one interrupt(); the
+# resumed results become real ToolMessages on the turn; the AIMessage is left
+# untouched; the state update carries messages and nothing else. Flag off
+# changes nothing.
 
 _FE_ACTION = {"function": {"name": "navigate"}}
 _FE_CALL = {"id": "fe-1", "name": "navigate", "args": {"path": "/x"}}
@@ -2411,9 +2411,8 @@ def test_flat_action_descriptors_are_matched():
 
 
 def test_placeholder_tool_message_does_not_count_as_an_answer():
-    """A checkpointer that runs patch_orphan_tool_calls injects a placeholder
-    for the paused call. Treating it as an answer would skip the interrupt and
-    hand the model "was interrupted before completion" as the tool's output."""
+    """A placeholder from patch_orphan_tool_calls must not count as an answer, or
+    the model gets "was interrupted before completion" as the tool's output."""
     placeholder = ToolMessage(
         content="Tool call 'navigate' with id 'fe-1' was interrupted before completion.",
         tool_call_id="fe-1",
@@ -2504,8 +2503,7 @@ def test_resume_payload_shapes(resume, expected):
 
 
 def test_unanswered_call_still_gets_a_paired_tool_message():
-    """Every tool_call must end up paired — Bedrock rejects an unanswered one
-    outright, and other providers handle it inconsistently."""
+    """Every tool_call must end up paired — Bedrock rejects an unanswered one."""
     state = _interrupt_state([_FE_CALL, _FE_CALL_2])
     resume = {"tool_results": [{"toolCallId": "fe-1", "content": "only-one"}]}
 
@@ -2534,9 +2532,7 @@ def test_client_answering_nothing_is_not_an_error(resume):
     ids=["none", "bare-string", "human-answer", "empty-dict", "number"],
 )
 def test_unrecognised_resume_payload_fails_loudly(resume):
-    """A resume carries one value and the first pending interrupt consumes it,
-    so another interrupt's answer can land here. Fabricating tool results from
-    it would leave the developer debugging a model apology."""
+    """An unrecognised payload must fail loudly rather than fabricate results."""
     with pytest.raises(CopilotKitMisuseError, match="interrupt_frontend_tools"):
         _run_after_model(_interrupt_state([_FE_CALL]), resume)
 
@@ -2561,9 +2557,8 @@ def test_after_agent_is_a_no_op_in_interrupt_mode():
 
 
 def test_next_model_call_sees_the_real_frontend_result():
-    """The point of the feature: the model resumes the same turn with the real
-    result, not the {"status": "forwarded_to_frontend"} placeholder the default
-    path substitutes."""
+    """The model gets the real result, not the default path's
+    {"status": "forwarded_to_frontend"} placeholder."""
     state = _interrupt_state([_BE_CALL, _FE_CALL])
     resume = {"tool_results": [{"toolCallId": "fe-1", "content": '{"page": "/x"}'}]}
 

--- a/sdk-python/tests/test_frontend_tool_interrupt.py
+++ b/sdk-python/tests/test_frontend_tool_interrupt.py
@@ -96,7 +96,7 @@ def _fe_call(call_id="fe-1", path="/x"):
     return {"id": call_id, "name": FE_TOOL_NAME, "args": {"path": path}}
 
 
-def _build(*, responses, interrupt_frontend_tools=True, tools=(), checkpointer=True):
+def _build(*, responses, interrupt_frontend_tools=True, tools=()):
     script: dict[str, Any] = {"responses": list(responses), "seen": []}
     graph = create_agent(
         model=_ScriptedModel(script=script),
@@ -104,7 +104,7 @@ def _build(*, responses, interrupt_frontend_tools=True, tools=(), checkpointer=T
         middleware=[
             CopilotKitMiddleware(interrupt_frontend_tools=interrupt_frontend_tools)
         ],
-        checkpointer=InMemorySaver() if checkpointer else None,
+        checkpointer=InMemorySaver(),
     )
     return graph, script
 
@@ -279,18 +279,6 @@ def test_flag_off_never_interrupts():
     assert _interrupt_payloads(events) == []
     # Stripped, so the turn ends here and the result arrives on the next run.
     assert len(script["seen"]) == 1
-
-
-def test_missing_checkpointer_fails_with_a_message_naming_the_flag():
-    graph, _ = _build(responses=[_ai([_fe_call()])], tools=[], checkpointer=False)
-
-    with pytest.raises(CopilotKitMisuseError, match="interrupt_frontend_tools"):
-        graph.invoke(
-            {
-                "messages": [],
-                "copilotkit": {"actions": [{"name": FE_TOOL_NAME}]},
-            }
-        )
 
 
 @pytest.mark.skipif(

--- a/sdk-python/tests/test_frontend_tool_interrupt.py
+++ b/sdk-python/tests/test_frontend_tool_interrupt.py
@@ -26,20 +26,14 @@ from langgraph.checkpoint.memory import InMemorySaver
 import pytest
 
 from copilotkit import CopilotKitMiddleware
-from copilotkit.exc import CopilotKitMisuseError
 from copilotkit.langgraph_agui_agent import LangGraphAGUIAgent
 
 FE_TOOL_NAME = "navigate"
 INTERRUPT_KEY = "__copilotkit_frontend_tool_calls__"
 
-# LangGraph's interrupt() reads the run config through a contextvar, which does
-# not propagate into asyncio tasks before Python 3.11 — so no interrupt can fire
-# from an async node on 3.10. That is a platform limit, not a CopilotKit one;
-# the middleware turns it into an actionable error, pinned by
-# test_async_on_python_310_explains_the_version_requirement below.
 requires_async_interrupt = pytest.mark.skipif(
     sys.version_info < (3, 11),
-    reason="interrupt() from an async node requires Python 3.11+",
+    reason="LangGraph's interrupt() needs Python 3.11+ under async",
 )
 
 
@@ -314,15 +308,3 @@ def test_agent_without_backend_tools_still_loops_back_to_the_model():
         "after_model cannot route back to the model, so the frontend results "
         f"would never reach it; edges go to {sorted(after_model_targets)}"
     )
-
-
-@pytest.mark.skipif(
-    sys.version_info >= (3, 11), reason="only 3.10 hits the contextvar limit"
-)
-def test_async_on_python_310_explains_the_version_requirement():
-    """Rather than LangGraph's "Called get_config outside of a runnable context",
-    which says nothing about the flag or the fix."""
-    graph, _ = _build(responses=[_ai([_fe_call()])], tools=[])
-
-    with pytest.raises(CopilotKitMisuseError, match="Python 3.11"):
-        _run(graph)

--- a/sdk-python/tests/test_frontend_tool_interrupt.py
+++ b/sdk-python/tests/test_frontend_tool_interrupt.py
@@ -1,0 +1,305 @@
+"""End-to-end coverage for ``CopilotKitMiddleware(interrupt_frontend_tools=True)``.
+
+These run real ``create_agent`` graphs through ``LangGraphAGUIAgent`` so the
+whole path is exercised: the batched ``interrupt()`` raised from ``after_model``,
+the AG-UI event the client sees, the ``forwardedProps.command.resume`` round
+trip, and the message history the model ends up with.
+
+The default (strip-and-restore) behaviour is covered by
+``test_intercepted_tool_call_events.py``; the tests here that touch it only
+assert that turning the flag off changes nothing.
+"""
+
+import asyncio
+import json
+import sys
+from typing import Any
+
+from ag_ui.core import EventType, Tool, UserMessage
+from ag_ui.core.types import RunAgentInput
+from langchain.agents import create_agent
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+import pytest
+
+from copilotkit import CopilotKitMiddleware
+from copilotkit.exc import CopilotKitMisuseError
+from copilotkit.langgraph_agui_agent import LangGraphAGUIAgent
+
+FE_TOOL_NAME = "navigate"
+INTERRUPT_KEY = "__copilotkit_frontend_tool_calls__"
+
+# LangGraph's interrupt() reads the run config through a contextvar, which does
+# not propagate into asyncio tasks before Python 3.11 — so no interrupt can fire
+# from an async node on 3.10. That is a platform limit, not a CopilotKit one;
+# the middleware turns it into an actionable error, pinned by
+# test_async_on_python_310_explains_the_version_requirement below.
+requires_async_interrupt = pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="interrupt() from an async node requires Python 3.11+",
+)
+
+
+class _ScriptedModel(BaseChatModel):
+    """Replays a scripted list of AIMessages and records what it was sent.
+
+    ``script`` is a plain dict shared *by reference* across the copies
+    ``bind_tools`` makes, so both the response queue and the record of what each
+    call saw survive re-binding — which ``create_agent`` does on every turn.
+    """
+
+    script: dict
+
+    def bind_tools(self, tools, **kwargs):
+        self.script["bound_tools"] = list(tools)
+        return self.__class__(script=self.script)
+
+    @property
+    def _llm_type(self) -> str:
+        return "scripted"
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        self.script["seen"].append(list(messages))
+        responses = self.script["responses"]
+        # Hold on the final response so an unexpected extra turn surfaces as a
+        # failed assertion rather than an IndexError.
+        response = responses.pop(0) if len(responses) > 1 else responses[0]
+        return ChatResult(generations=[ChatGeneration(message=response)])
+
+
+@tool
+def backend_search(q: str) -> str:
+    """Search the backend."""
+    return "backend-result"
+
+
+def _fe_tool(name: str = FE_TOOL_NAME) -> Tool:
+    return Tool(
+        name=name,
+        description="A frontend tool",
+        parameters={
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    )
+
+
+def _ai(tool_calls, *, msg_id="ai-1", content=""):
+    return AIMessage(content=content, id=msg_id, tool_calls=list(tool_calls))
+
+
+def _fe_call(call_id="fe-1", path="/x"):
+    return {"id": call_id, "name": FE_TOOL_NAME, "args": {"path": path}}
+
+
+def _build(*, responses, interrupt_frontend_tools=True, tools=(), checkpointer=True):
+    script: dict[str, Any] = {"responses": list(responses), "seen": []}
+    graph = create_agent(
+        model=_ScriptedModel(script=script),
+        tools=list(tools),
+        middleware=[
+            CopilotKitMiddleware(interrupt_frontend_tools=interrupt_frontend_tools)
+        ],
+        checkpointer=InMemorySaver() if checkpointer else None,
+    )
+    return graph, script
+
+
+def _run(graph, *, thread_id="t1", run_id="r1", forwarded_props=None, message_id="u1"):
+    agent = LangGraphAGUIAgent(name="test", graph=graph)
+    run_input = RunAgentInput(
+        threadId=thread_id,
+        runId=run_id,
+        state={},
+        messages=[UserMessage(id=message_id, content="hi")],
+        tools=[_fe_tool()],
+        context=[],
+        forwardedProps=forwarded_props or {},
+    )
+
+    async def _go():
+        return [event async for event in agent.run(run_input)]
+
+    return asyncio.run(_go())
+
+
+def _interrupt_payloads(events):
+    """Frontend-tool interrupt payloads carried by ``on_interrupt`` events.
+
+    ``ag-ui-langgraph`` 0.0.42 — the floor the CI matrix pins — has no
+    ``RunFinished(outcome=...)`` support, so the legacy CustomEvent is the only
+    channel an interrupt reaches the client through.
+    """
+    payloads = []
+    for event in events:
+        if getattr(event, "type", None) != EventType.CUSTOM:
+            continue
+        if getattr(event, "name", None) != "on_interrupt":
+            continue
+        value = getattr(event, "value", None)
+        # 0.0.42 serialises the interrupt value to a JSON string on the wire.
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except ValueError:
+                continue
+        if isinstance(value, dict) and INTERRUPT_KEY in value:
+            payloads.append(value[INTERRUPT_KEY])
+    return payloads
+
+
+def _resume(tool_results):
+    return {"command": {"resume": {"tool_results": tool_results}}}
+
+
+def _tool_messages(messages):
+    return [m for m in messages if isinstance(m, ToolMessage)]
+
+
+@requires_async_interrupt
+def test_all_frontend_turn_pauses_then_resumes_into_the_same_turn():
+    """The feature itself: the model gets the real result back in-run, in the
+    natural AIMessage -> ToolMessage order, without the turn ending first."""
+    graph, script = _build(
+        responses=[_ai([_fe_call()]), AIMessage(content="you are on /x", id="ai-2")],
+        tools=[],
+    )
+
+    first = _run(graph)
+
+    assert _interrupt_payloads(first) == [
+        [{"id": "fe-1", "name": FE_TOOL_NAME, "args": {"path": "/x"}}]
+    ]
+    assert len(script["seen"]) == 1, "the run must pause, not call the model again"
+
+    _run(
+        graph,
+        run_id="r2",
+        forwarded_props=_resume([{"toolCallId": "fe-1", "content": '{"page": "/x"}'}]),
+    )
+
+    assert len(script["seen"]) == 2, "resuming must re-enter the model"
+    second_call = script["seen"][1]
+    ai = next(m for m in second_call if isinstance(m, AIMessage))
+    assert [tc["id"] for tc in ai.tool_calls] == ["fe-1"], (
+        "the frontend call stays on the AIMessage — it is not stripped"
+    )
+    results = _tool_messages(second_call)
+    assert [(m.tool_call_id, m.content) for m in results] == [
+        ("fe-1", '{"page": "/x"}')
+    ]
+    assert second_call.index(ai) < second_call.index(results[0])
+
+
+@requires_async_interrupt
+def test_mixed_turn_runs_only_the_backend_call_through_the_tool_node():
+    """No ``jump_to`` is set, so the model->tools edge has to do the routing:
+    send the still-pending backend call to the ToolNode, skip the frontend one
+    now that it has a matching ToolMessage."""
+    graph, script = _build(
+        responses=[
+            _ai(
+                [
+                    {"id": "be-1", "name": "backend_search", "args": {"q": "hi"}},
+                    _fe_call(),
+                ]
+            ),
+            AIMessage(content="all done", id="ai-2"),
+        ],
+        tools=[backend_search],
+    )
+
+    first = _run(graph)
+    assert _interrupt_payloads(first) == [
+        [{"id": "fe-1", "name": FE_TOOL_NAME, "args": {"path": "/x"}}]
+    ]
+
+    _run(
+        graph,
+        run_id="r2",
+        forwarded_props=_resume([{"toolCallId": "fe-1", "content": "frontend-result"}]),
+    )
+
+    assert len(script["seen"]) == 2
+    results = _tool_messages(script["seen"][1])
+    assert {m.tool_call_id: m.content for m in results} == {
+        "fe-1": "frontend-result",
+        "be-1": "backend-result",
+    }
+
+
+@requires_async_interrupt
+def test_two_frontend_turns_on_one_thread():
+    graph, script = _build(
+        responses=[
+            _ai([_fe_call()]),
+            _ai([_fe_call("fe-2", "/y")], msg_id="ai-2"),
+            AIMessage(content="done", id="ai-3"),
+        ],
+        tools=[],
+    )
+
+    assert _interrupt_payloads(_run(graph))[0][0]["id"] == "fe-1"
+
+    second = _run(
+        graph,
+        run_id="r2",
+        forwarded_props=_resume([{"toolCallId": "fe-1", "content": "first"}]),
+    )
+    assert _interrupt_payloads(second)[0][0]["id"] == "fe-2"
+
+    _run(
+        graph,
+        run_id="r3",
+        forwarded_props=_resume([{"toolCallId": "fe-2", "content": "second"}]),
+    )
+
+    assert len(script["seen"]) == 3
+    final = script["seen"][2]
+    assert {m.tool_call_id: m.content for m in _tool_messages(final)} == {
+        "fe-1": "first",
+        "fe-2": "second",
+    }
+
+
+def test_flag_off_never_interrupts():
+    """Guards the default path against anything the opt-in branch changed."""
+    graph, script = _build(
+        responses=[_ai([_fe_call()]), AIMessage(content="done", id="ai-2")],
+        tools=[],
+        interrupt_frontend_tools=False,
+    )
+
+    events = _run(graph)
+
+    assert _interrupt_payloads(events) == []
+    # Stripped, so the turn ends here and the result arrives on the next run.
+    assert len(script["seen"]) == 1
+
+
+def test_missing_checkpointer_fails_with_a_message_naming_the_flag():
+    graph, _ = _build(responses=[_ai([_fe_call()])], tools=[], checkpointer=False)
+
+    with pytest.raises(CopilotKitMisuseError, match="interrupt_frontend_tools"):
+        graph.invoke(
+            {
+                "messages": [],
+                "copilotkit": {"actions": [{"name": FE_TOOL_NAME}]},
+            }
+        )
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11), reason="only 3.10 hits the contextvar limit"
+)
+def test_async_on_python_310_explains_the_version_requirement():
+    """Rather than LangGraph's "Called get_config outside of a runnable context",
+    which says nothing about the flag or the fix."""
+    graph, _ = _build(responses=[_ai([_fe_call()])], tools=[])
+
+    with pytest.raises(CopilotKitMisuseError, match="Python 3.11"):
+        _run(graph)

--- a/sdk-python/tests/test_frontend_tool_interrupt.py
+++ b/sdk-python/tests/test_frontend_tool_interrupt.py
@@ -1,13 +1,9 @@
 """End-to-end coverage for ``CopilotKitMiddleware(interrupt_frontend_tools=True)``.
 
-These run real ``create_agent`` graphs through ``LangGraphAGUIAgent`` so the
-whole path is exercised: the batched ``interrupt()`` raised from ``after_model``,
-the AG-UI event the client sees, the ``forwardedProps.command.resume`` round
-trip, and the message history the model ends up with.
-
-The default (strip-and-restore) behaviour is covered by
-``test_intercepted_tool_call_events.py``; the tests here that touch it only
-assert that turning the flag off changes nothing.
+These run real ``create_agent`` graphs through ``LangGraphAGUIAgent``: the
+batched ``interrupt()`` from ``after_model``, the AG-UI event the client sees,
+the ``forwardedProps.command.resume`` round trip, and the resulting history. The
+default path is covered by ``test_intercepted_tool_call_events.py``.
 """
 
 import asyncio
@@ -40,9 +36,8 @@ requires_async_interrupt = pytest.mark.skipif(
 class _ScriptedModel(BaseChatModel):
     """Replays a scripted list of AIMessages and records what it was sent.
 
-    ``script`` is a plain dict shared *by reference* across the copies
-    ``bind_tools`` makes, so both the response queue and the record of what each
-    call saw survive re-binding — which ``create_agent`` does on every turn.
+    ``script`` is shared *by reference* across the copies ``bind_tools`` makes,
+    which ``create_agent`` does on every turn.
     """
 
     script: dict
@@ -58,8 +53,7 @@ class _ScriptedModel(BaseChatModel):
     def _generate(self, messages, stop=None, run_manager=None, **kwargs):
         self.script["seen"].append(list(messages))
         responses = self.script["responses"]
-        # Hold on the final response so an unexpected extra turn surfaces as a
-        # failed assertion rather than an IndexError.
+        # Hold the final response so an extra turn fails an assert, not IndexError.
         response = responses.pop(0) if len(responses) > 1 else responses[0]
         return ChatResult(generations=[ChatGeneration(message=response)])
 
@@ -124,9 +118,8 @@ def _run(graph, *, thread_id="t1", run_id="r1", forwarded_props=None, message_id
 def _interrupt_payloads(events):
     """Frontend-tool interrupt payloads carried by ``on_interrupt`` events.
 
-    ``ag-ui-langgraph`` 0.0.42 — the floor the CI matrix pins — has no
-    ``RunFinished(outcome=...)`` support, so the legacy CustomEvent is the only
-    channel an interrupt reaches the client through.
+    ``ag-ui-langgraph`` 0.0.42 (the CI floor) has no ``RunFinished(outcome=...)``,
+    so the legacy CustomEvent is the only channel for an interrupt.
     """
     payloads = []
     for event in events:
@@ -278,17 +271,10 @@ def test_flag_off_never_interrupts():
 def test_agent_without_backend_tools_still_loops_back_to_the_model():
     """Pins what makes ``jump_to`` unnecessary in ``_await_frontend_tool_calls``.
 
-    ``create_agent`` builds a ``tools`` node when there are tools *or* when a
-    middleware wraps tool calls. ``CopilotKitMiddleware`` defines
-    ``wrap_tool_call``/``awrap_tool_call``, so the node exists even at
-    ``tools=[]`` — and with it the conditional edge whose "tool calls, none
-    pending" branch re-enters the model once the frontend results are in.
-
-    Drop those wrappers and ``after_model`` collapses to a single plain edge to
-    the exit node, so every resume would end the run instead of letting the
-    model react. Nothing raises when that happens: the turn just stops. Assert
-    the wiring here so the cause is named, rather than leaving it to surface as
-    a missing second model call elsewhere.
+    ``create_agent`` builds the tools node when there are tools *or* a middleware
+    wraps tool calls, so ``CopilotKitMiddleware``'s wrappers keep the node — and
+    the conditional edge back to the model — alive even at ``tools=[]``. Without
+    them every resume silently ends the run.
     """
     graph, _ = _build(responses=[_ai([_fe_call()])], tools=[])
     drawable = graph.get_graph()

--- a/sdk-python/tests/test_frontend_tool_interrupt.py
+++ b/sdk-python/tests/test_frontend_tool_interrupt.py
@@ -281,6 +281,41 @@ def test_flag_off_never_interrupts():
     assert len(script["seen"]) == 1
 
 
+def test_agent_without_backend_tools_still_loops_back_to_the_model():
+    """Pins what makes ``jump_to`` unnecessary in ``_await_frontend_tool_calls``.
+
+    ``create_agent`` builds a ``tools`` node when there are tools *or* when a
+    middleware wraps tool calls. ``CopilotKitMiddleware`` defines
+    ``wrap_tool_call``/``awrap_tool_call``, so the node exists even at
+    ``tools=[]`` — and with it the conditional edge whose "tool calls, none
+    pending" branch re-enters the model once the frontend results are in.
+
+    Drop those wrappers and ``after_model`` collapses to a single plain edge to
+    the exit node, so every resume would end the run instead of letting the
+    model react. Nothing raises when that happens: the turn just stops. Assert
+    the wiring here so the cause is named, rather than leaving it to surface as
+    a missing second model call elsewhere.
+    """
+    graph, _ = _build(responses=[_ai([_fe_call()])], tools=[])
+    drawable = graph.get_graph()
+
+    assert "tools" in drawable.nodes, (
+        "create_agent built no ToolNode for a tools=[] agent. CopilotKitMiddleware "
+        "has to keep defining wrap_tool_call/awrap_tool_call, or after_model's "
+        "only edge is to the exit node and resuming silently ends the run."
+    )
+
+    after_model_targets = {
+        edge.target
+        for edge in drawable.edges
+        if edge.source.endswith(".after_model")
+    }
+    assert "model" in after_model_targets, (
+        "after_model cannot route back to the model, so the frontend results "
+        f"would never reach it; edges go to {sorted(after_model_targets)}"
+    )
+
+
 @pytest.mark.skipif(
     sys.version_info >= (3, 11), reason="only 3.10 hits the contextvar limit"
 )

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
@@ -242,14 +242,12 @@ reads the way a backend tool call does:
 Agent calls a tool → tool runs on the client → ToolMessage appended → agent continues
 ```
 
-<Callout type="warn" title="This is opt-in for four reasons">
-1. **A checkpointer is required.** The run pauses and has to be restored when the client resumes.
-   Without one the middleware raises `CopilotKitMisuseError`.
-2. **Python 3.11+ is required.** Below that, the run config does not propagate into asyncio tasks, so
+<Callout type="warn" title="This is opt-in for three reasons">
+1. **Python 3.11+ is required.** Below that, the run config does not propagate into asyncio tasks, so
    `interrupt()` cannot read it. This limits every async `interrupt()`, not just this flag.
-3. **The client must resume explicitly.** The default frontend-tool loop fires a plain follow-up run,
+2. **The client must resume explicitly.** The default frontend-tool loop fires a plain follow-up run,
    which a paused thread ignores. You need the handler below.
-4. **All frontend calls in a turn share one interrupt.** A resume carries a single value and cannot
+3. **All frontend calls in a turn share one interrupt.** A resume carries a single value and cannot
    address several pending interrupts without their ids
    ([ag-ui#2178](https://github.com/ag-ui-protocol/ag-ui/issues/2178)), so the middleware batches them.
 </Callout>
@@ -266,7 +264,7 @@ graph = create_agent(
     tools=[],  # backend tools go here
     # [!code highlight:2]
     middleware=[CopilotKitMiddleware(interrupt_frontend_tools=True)],
-    checkpointer=InMemorySaver(),  # required — swap in a durable saver for production
+    checkpointer=InMemorySaver(),  # use a durable saver in production
 )
 ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
@@ -242,12 +242,10 @@ reads the way a backend tool call does:
 Agent calls a tool → tool runs on the client → ToolMessage appended → agent continues
 ```
 
-<Callout type="warn" title="This is opt-in for three reasons">
-1. **Python 3.11+ is required.** Below that, the run config does not propagate into asyncio tasks, so
-   `interrupt()` cannot read it. This limits every async `interrupt()`, not just this flag.
-2. **The client must resume explicitly.** The default frontend-tool loop fires a plain follow-up run,
+<Callout type="warn" title="This is opt-in for two reasons">
+1. **The client must resume explicitly.** The default frontend-tool loop fires a plain follow-up run,
    which a paused thread ignores. You need the handler below.
-3. **All frontend calls in a turn share one interrupt.** A resume carries a single value and cannot
+2. **All frontend calls in a turn share one interrupt.** A resume carries a single value and cannot
    address several pending interrupts without their ids
    ([ag-ui#2178](https://github.com/ag-ui-protocol/ag-ui/issues/2178)), so the middleware batches them.
 </Callout>

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
@@ -226,3 +226,118 @@ useFrontendTool({
 In addition to letting the LLM decide when to call a frontend tool, you can emit tool calls directly from your LangGraph node code using `copilotkit_emit_tool_call`. This fires the `useFrontendTool` handler immediately, without waiting for an LLM decision.
 
 See [Connecting Backend Emit APIs to Frontend Hooks](/integrations/langgraph/advanced/emit-api-hook-mapping) for an end-to-end guide covering `copilotkit_emit_tool_call`, `copilotkit_customize_config`, and how they relate to `useFrontendTool` and `useComponent`.
+
+## Awaiting frontend tool results in the same turn
+
+By default, a frontend tool call ends the agent's turn. CopilotKit peels the call off the assistant
+message so the backend `ToolNode` does not try to run it, the client executes it, and the result
+reaches the agent on the *next* run. The agent never sees the result while it is still reasoning.
+
+`CopilotKitMiddleware(interrupt_frontend_tools=True)` opts into the alternative: the graph pauses on a
+LangGraph `interrupt()`, the client executes the tools and resumes, and a real `ToolMessage` is
+appended to the same turn. The agent continues with the results in hand, and the persisted history
+reads the way a backend tool call does:
+
+```text
+Agent calls a tool → tool runs on the client → ToolMessage appended → agent continues
+```
+
+<Callout type="warn" title="This is opt-in for four reasons">
+1. **A checkpointer is required.** The run pauses and has to be restored when the client resumes.
+   Without one the middleware raises `CopilotKitMisuseError`.
+2. **Python 3.11+ is required.** Below that, the run config does not propagate into asyncio tasks, so
+   `interrupt()` cannot read it. This limits every async `interrupt()`, not just this flag.
+3. **The client must resume explicitly.** The default frontend-tool loop fires a plain follow-up run,
+   which a paused thread ignores. You need the handler below.
+4. **All frontend calls in a turn share one interrupt.** A resume carries a single value and cannot
+   address several pending interrupts without their ids
+   ([ag-ui#2178](https://github.com/ag-ui-protocol/ag-ui/issues/2178)), so the middleware batches them.
+</Callout>
+
+### Enable it on the agent
+
+```python title="agent.py"
+from langchain.agents import create_agent
+from langgraph.checkpoint.memory import InMemorySaver
+from copilotkit import CopilotKitMiddleware
+
+graph = create_agent(
+    model="openai:gpt-4o",
+    tools=[],  # backend tools go here
+    # [!code highlight:2]
+    middleware=[CopilotKitMiddleware(interrupt_frontend_tools=True)],
+    checkpointer=InMemorySaver(),  # required — swap in a durable saver for production
+)
+```
+
+When the agent calls a frontend tool, the graph pauses and the client receives an interrupt whose
+value carries every call in the turn:
+
+```json
+{
+  "__copilotkit_frontend_tool_calls__": [
+    { "id": "call_123", "name": "navigate", "args": { "path": "/reports" } }
+  ]
+}
+```
+
+### Resume it on the client
+
+Mount a `useInterrupt` handler that dispatches each call to its registered frontend tool and resumes
+with the results. `renderInChat: false` keeps it headless — this interrupt asks nothing of the user:
+
+```tsx title="app/page.tsx"
+import { useCopilotKit, useInterrupt } from "@copilotkit/react-core/v2";
+
+const FRONTEND_TOOL_CALLS = "__copilotkit_frontend_tool_calls__";
+
+type FrontendToolCall = { id: string; name: string; args: Record<string, unknown> };
+
+function useFrontendToolInterrupt() {
+  const { copilotkit } = useCopilotKit();
+
+  useInterrupt<{ [FRONTEND_TOOL_CALLS]?: FrontendToolCall[] }>({
+    renderInChat: false,
+    render: () => null,
+    // Leave every other interrupt — including your own human-facing ones — alone.
+    enabled: ({ value }) => Boolean(value && FRONTEND_TOOL_CALLS in value),
+    handler: async ({ event, resolve }) => {
+      const calls = event.value?.[FRONTEND_TOOL_CALLS] ?? [];
+
+      const tool_results = await Promise.all(
+        calls.map(async (call) => {
+          try {
+            const tool = copilotkit.getTool({ toolName: call.name });
+            const result = await tool?.handler?.(call.args, { toolCall: call } as never);
+            return {
+              toolCallId: call.id,
+              content: typeof result === "string" ? result : JSON.stringify(result ?? null),
+            };
+          } catch (error) {
+            // Resume anyway — a thrown handler must not strand the paused run.
+            return {
+              toolCallId: call.id,
+              content: JSON.stringify({ ok: false, error: String(error) }),
+            };
+          }
+        }),
+      );
+
+      await resolve({ tool_results });
+    },
+  });
+}
+```
+
+`resolve()` sends `forwardedProps.command.resume`, which LangGraph hands back as the return value of
+`interrupt()`. The middleware then appends one `ToolMessage` per call and re-enters the model.
+
+Any call you do not answer still gets a `ToolMessage`, with content
+`{"ok": false, "error": "missing_tool_result"}` — every tool call has to stay paired with a result, or
+providers such as Bedrock reject the conversation outright.
+
+<Callout type="info">
+First-class client support for this flow is planned; until then the handler above is the supported
+way to wire it. For interrupts that *do* ask the user something, see
+[Human in the Loop](/integrations/langgraph/human-in-the-loop/interrupt-flow).
+</Callout>

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
@@ -308,9 +308,7 @@ export type InterruptWidget<Args = Record<string, unknown>> = FC<{
   responded: boolean;
 }>;
 
-// `ag_ui_langgraph` sends the interrupt value through `dump_json_safe`, which yields a
-// JSON *string* on the wire; other versions pass an object. Parse both, or `KEY in value`
-// throws on the string.
+// Some adapter versions send the value JSON-encoded; parse before indexing.
 function readCalls(value: unknown): FrontendToolCall[] | null {
   let parsed: unknown = value;
   if (typeof parsed === "string") {
@@ -337,9 +335,8 @@ function InterruptDispatcher({
   const interactive = calls.filter((c) => c.name in widgets);
   const [responses, setResponses] = useState<Record<string, unknown>>({});
 
-  // A ref, not state: Strict Mode runs mount effects twice in development, and a state
-  // guard still reads its pre-commit value on the second pass — resolving twice, which
-  // posts two resumes and starts two runs on the thread.
+  // A ref, not state: a state guard still reads its pre-commit value on Strict
+  // Mode's second pass and resolves twice.
   const resolved = useRef(false);
 
   const resolveBatch = useCallback(() => {
@@ -383,8 +380,7 @@ export function useFrontendInterruptBridge(
   widgets: Record<string, InterruptWidget<any>>,
   agentId = "default",
 ) {
-  // Read the registry through a ref so callers can pass an inline literal without
-  // changing `render`'s identity on every commit.
+  // Via a ref, so an inline registry literal cannot change `render`'s identity.
   const widgetsRef = useRef(widgets);
   widgetsRef.current = widgets;
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
@@ -287,8 +287,9 @@ Each frontend tool falls into one of two shapes:
 
 - **Interactive** — needs user input before the agent may continue. Register a widget; the bridge waits
   for it.
-- **Fire-and-forget or display-only** — no input needed. The bridge auto-acks it, and any visuals come
-  from that tool's own `useFrontendTool({ render })` registration, which outlives the pause.
+- **Fire-and-forget or display-only** — no input needed. The bridge answers it with a placeholder
+  result, and any visuals come from that tool's own `useFrontendTool({ render })` registration, which
+  outlives the pause.
 
 ```tsx title="frontend-interrupt-bridge.tsx"
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -345,7 +346,7 @@ function InterruptDispatcher({
     resolve({
       tool_results: calls.map((c) => ({
         toolCallId: c.id,
-        // Unanswered calls are acked, not omitted: every tool_call needs a result.
+        // Every tool_call needs a result, so unanswered calls get a placeholder.
         content: JSON.stringify(c.id in responses ? responses[c.id] : { ok: true }),
       })),
     });
@@ -417,8 +418,8 @@ function App() {
 `resolve()` sends `forwardedProps.command.resume`, which LangGraph hands back as the return value of
 `interrupt()`. The middleware then appends one `ToolMessage` per call and re-enters the model.
 
-Any call you do not answer still gets a `ToolMessage`. If the bridge acks it, that ack is the content;
-if the client resumes without mentioning it at all, the middleware substitutes
+Any call you do not answer still gets a `ToolMessage`. If the bridge supplied a placeholder, that is
+the content; if the client resumes without mentioning the call at all, the middleware substitutes
 `{"ok": false, "error": "missing_tool_result"}` — every tool call has to stay paired with a result, or
 providers such as Bedrock reject the conversation outright.
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
@@ -338,7 +338,6 @@ answered through the interrupt can also be run by the default frontend-tool path
 </Callout>
 
 <Callout type="info">
-First-class client support for this flow is planned; until then the handler above is the supported
-way to wire it. For interrupts that *do* ask the user something, see
+For interrupts that *do* ask the user something, see
 [Human in the Loop](/integrations/langgraph/human-in-the-loop/interrupt-flow).
 </Callout>

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
@@ -332,6 +332,11 @@ Any call you do not answer still gets a `ToolMessage`, with content
 `{"ok": false, "error": "missing_tool_result"}` — every tool call has to stay paired with a result, or
 providers such as Bedrock reject the conversation outright.
 
+<Callout type="warn">
+Keep these handlers idempotent. The client's post-run tool executor is not interrupt-aware, so a call
+answered through the interrupt can also be run by the default frontend-tool path.
+</Callout>
+
 <Callout type="info">
 First-class client support for this flow is planned; until then the handler above is the supported
 way to wire it. For interrupts that *do* ask the user something, see

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
@@ -279,62 +279,165 @@ value carries every call in the turn:
 
 ### Resume it on the client
 
-Mount a `useInterrupt` handler that dispatches each call to its registered frontend tool and resumes
-with the results. `renderInChat: false` keeps it headless — this interrupt asks nothing of the user:
+Mount one `useInterrupt` bridge that claims these interrupts and answers the whole batch. It resolves
+from `render` rather than `handler`, which is what lets a call ask the user something before the run
+continues — see the caution below for why `handler` cannot.
 
-```tsx title="app/page.tsx"
-import { useCopilotKit, useInterrupt } from "@copilotkit/react-core/v2";
+Each frontend tool falls into one of two shapes:
+
+- **Interactive** — needs user input before the agent may continue. Register a widget; the bridge waits
+  for it.
+- **Fire-and-forget or display-only** — no input needed. The bridge auto-acks it, and any visuals come
+  from that tool's own `useFrontendTool({ render })` registration, which outlives the pause.
+
+```tsx title="frontend-interrupt-bridge.tsx"
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { FC, ReactNode } from "react";
+import { useInterrupt } from "@copilotkit/react-core/v2";
+import type { InterruptEvent, InterruptRenderProps } from "@copilotkit/react-core/v2";
 
 const FRONTEND_TOOL_CALLS = "__copilotkit_frontend_tool_calls__";
 
-type FrontendToolCall = { id: string; name: string; args: Record<string, unknown> };
+type FrontendToolCall<Args = Record<string, unknown>> = { id: string; name: string; args: Args };
 
-function useFrontendToolInterrupt() {
-  const { copilotkit } = useCopilotKit();
+export type InterruptWidget<Args = Record<string, unknown>> = FC<{
+  call: FrontendToolCall<Args>;
+  /** Resolve this call. Pass the object to become the tool's ToolMessage content. */
+  respond: (result: unknown) => void;
+  /** True once `respond` has been called — disable inputs on it. */
+  responded: boolean;
+}>;
 
-  useInterrupt<{ [FRONTEND_TOOL_CALLS]?: FrontendToolCall[] }>({
-    renderInChat: false,
-    render: () => null,
-    // Leave every other interrupt — including your own human-facing ones — alone.
-    enabled: ({ value }) => Boolean(value && FRONTEND_TOOL_CALLS in value),
-    handler: async ({ event, resolve }) => {
-      const calls = event.value?.[FRONTEND_TOOL_CALLS] ?? [];
+// `ag_ui_langgraph` sends the interrupt value through `dump_json_safe`, which yields a
+// JSON *string* on the wire; other versions pass an object. Parse both, or `KEY in value`
+// throws on the string.
+function readCalls(value: unknown): FrontendToolCall[] | null {
+  let parsed: unknown = value;
+  if (typeof parsed === "string") {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch {
+      return null;
+    }
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const calls = (parsed as Record<string, unknown>)[FRONTEND_TOOL_CALLS];
+  return Array.isArray(calls) ? (calls as FrontendToolCall[]) : null;
+}
 
-      const tool_results = await Promise.all(
-        calls.map(async (call) => {
-          try {
-            const tool = copilotkit.getTool({ toolName: call.name });
-            const result = await tool?.handler?.(call.args, { toolCall: call } as never);
-            return {
-              toolCallId: call.id,
-              content: typeof result === "string" ? result : JSON.stringify(result ?? null),
-            };
-          } catch (error) {
-            // Resume anyway — a thrown handler must not strand the paused run.
-            return {
-              toolCallId: call.id,
-              content: JSON.stringify({ ok: false, error: String(error) }),
-            };
-          }
-        }),
-      );
+function InterruptDispatcher({
+  calls,
+  resolve,
+  widgets,
+}: {
+  calls: FrontendToolCall[];
+  resolve: (response: unknown) => void;
+  widgets: Record<string, InterruptWidget<any>>;
+}): ReactNode {
+  const interactive = calls.filter((c) => c.name in widgets);
+  const [responses, setResponses] = useState<Record<string, unknown>>({});
 
-      await resolve({ tool_results });
-    },
-  });
+  // A ref, not state: Strict Mode runs mount effects twice in development, and a state
+  // guard still reads its pre-commit value on the second pass — resolving twice, which
+  // posts two resumes and starts two runs on the thread.
+  const resolved = useRef(false);
+
+  const resolveBatch = useCallback(() => {
+    if (resolved.current) return;
+    resolved.current = true;
+    resolve({
+      tool_results: calls.map((c) => ({
+        toolCallId: c.id,
+        // Unanswered calls are acked, not omitted: every tool_call needs a result.
+        content: JSON.stringify(c.id in responses ? responses[c.id] : { ok: true }),
+      })),
+    });
+  }, [calls, responses, resolve]);
+
+  useEffect(() => {
+    if (Object.keys(responses).length === interactive.length) resolveBatch();
+  }, [responses, interactive.length, resolveBatch]);
+
+  if (interactive.length === 0) return null;
+
+  return (
+    <>
+      {interactive.map((c) => {
+        const Widget = widgets[c.name];
+        return (
+          <Widget
+            key={c.id}
+            call={c}
+            responded={c.id in responses}
+            respond={(result) =>
+              setResponses((prev) => (c.id in prev ? prev : { ...prev, [c.id]: result }))
+            }
+          />
+        );
+      })}
+    </>
+  );
+}
+
+export function useFrontendInterruptBridge(
+  widgets: Record<string, InterruptWidget<any>>,
+  agentId = "default",
+) {
+  // Read the registry through a ref so callers can pass an inline literal without
+  // changing `render`'s identity on every commit.
+  const widgetsRef = useRef(widgets);
+  widgetsRef.current = widgets;
+
+  const enabled = useCallback(
+    (event: InterruptEvent<unknown>) => readCalls(event?.value) !== null,
+    [],
+  );
+
+  const render = useCallback(({ event, resolve }: InterruptRenderProps<unknown, unknown>) => {
+    const calls = readCalls(event.value);
+    if (!calls) return <></>;
+    return <InterruptDispatcher calls={calls} resolve={resolve} widgets={widgetsRef.current} />;
+  }, []);
+
+  useInterrupt({ agentId, enabled, render });
+}
+```
+
+Register it once, passing widgets only for the tools that need input:
+
+```tsx title="app/page.tsx"
+const ConfirmNavigation: InterruptWidget<{ path: string }> = ({ call, respond, responded }) => (
+  <button disabled={responded} onClick={() => respond({ approved: true })}>
+    Go to {call.args.path}
+  </button>
+);
+
+function App() {
+  useFrontendInterruptBridge({ confirmNavigation: ConfirmNavigation });
+  // ...
 }
 ```
 
 `resolve()` sends `forwardedProps.command.resume`, which LangGraph hands back as the return value of
 `interrupt()`. The middleware then appends one `ToolMessage` per call and re-enters the model.
 
-Any call you do not answer still gets a `ToolMessage`, with content
+Any call you do not answer still gets a `ToolMessage`. If the bridge acks it, that ack is the content;
+if the client resumes without mentioning it at all, the middleware substitutes
 `{"ok": false, "error": "missing_tool_result"}` — every tool call has to stay paired with a result, or
 providers such as Bedrock reject the conversation outright.
 
-<Callout type="warn">
-Keep these handlers idempotent. The client's post-run tool executor is not interrupt-aware, so a call
-answered through the interrupt can also be run by the default frontend-tool path.
+<Callout type="warn" title="Four things to get right">
+1. **Keep handlers idempotent.** The client's post-run tool executor is not interrupt-aware, so a call
+   answered through the interrupt can also be run by the default frontend-tool path.
+2. **Resolve exactly once.** Two resumes for one pause means two runs on the same thread. Guard with a
+   ref, not state — React Strict Mode invokes mount effects twice in development.
+3. **Keep `enabled` and `render` stable** (`useCallback` with empty deps, reading anything mutable
+   through a ref). New identities rebuild the rendered element and discard in-progress widget state.
+4. **Don't answer these by dispatching to a tool's own handler.** Calling a handler directly never
+   marks the call as executing, so a [`useHumanInTheLoop`](/human-in-the-loop/useInterrupt) tool never
+   receives a live `respond` and the pause never ends. That is why the bridge above resolves from
+   `render`; a fire-and-forget tool's handler still runs through the default path, which is also why
+   point 1 matters.
 </Callout>
 
 <Callout type="info">

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/human-in-the-loop/interrupt-flow.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/human-in-the-loop/interrupt-flow.mdx
@@ -16,6 +16,12 @@ description: Learn how to implement Human-in-the-Loop (HITL) using a interrupt-b
   This example demonstrates interrupt-based human-in-the-loop (HITL) in the [CopilotKit Feature Viewer](https://feature-viewer.copilotkit.ai/langgraph/feature/human_in_the_loop).
 </Callout>
 
+<Callout type="info">
+  Interrupts can also back frontend *tools*, so the agent awaits a client-side tool result mid-turn
+  instead of ending its turn. See
+  [Awaiting frontend tool results in the same turn](/integrations/langgraph/frontend-tools#awaiting-frontend-tool-results-in-the-same-turn).
+</Callout>
+
 ## What is this?
 
 [LangGraph's interrupt flow](https://docs.langchain.com/oss/python/langgraph/interrupts) provides an intuitive way to implement Human-in-the-loop workflows.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.


**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.com/invite/6dffbvGU3D


You can learn more about contributing to copilotkit here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds `CopilotKitMiddleware(interrupt_frontend_tools=True)`.
An opt-in path that awaits frontend tool results **in the same turn** via LangGraph's `interrupt()`, instead of the default strip-and-restore (which carries several complications).

[Python middleware only]

#### Default path

On the default path `after_model` strips frontend tool calls off the `AIMessage` and `after_agent`
restores them, so the result only reaches the model on the *next* run. 

```
Agent calls any tools → FE calls stripped → turn ends → FE tool runs on the client → FE ToolMessage arrives on the next run
```
In a mixed turn the graph does not even end: the backend call runs and the frontend call is restored
with a `{"status": "forwarded_to_frontend"}` placeholder, since an unpaired `tool_call` is invalid.

So human-in-the-loop on a frontend tool is not possible here, as the graph moves on before the user is
asked, and their answer lands a run after the decision it should have gated. It is fragile too as there is no clear interruption contract for the langgraph graph.

#### New path

Meanwhile, with the new flag `interrupt_frontend_tools=True`:

```
Agent calls any tools → FE tool runs on the client → FE ToolMessage appended → agent continues
```

So the model builds `AIMessage` → `ToolMessage` straight away, as if it called an MCP server for
those tools.


<details><summary>How it works in mode detail</summary>

Basically:
1. After model response, collect all FE tools a model might have requested in parallel, 
2. then `interrupt()` and wait for FE to `resume` with all the FE tool responses (No matter if it's a fire-and-forget tool, HITL or other.)
3. After resume, agent continues as before (either run backend tools or loops back to model).

In more detail:

- `after_model` batches a turn's unanswered frontend calls into one `interrupt()`, keyed
  `__copilotkit_frontend_tool_calls__` so a client can distinguish it from a human-facing interrupt on
  the same thread.
- The client resumes with `{"tool_results": [{"toolCallId": ..., "content": ...}, ...]}`. The middleware
  appends one `ToolMessage` per call and the model re-enters the same turn.
- The `AIMessage` is left untouched, so each new `ToolMessage` has a matching id. Unanswered calls still
  get one, because an unpaired `tool_call` is rejected by Bedrock.
- One interrupt per turn rather than one per call: `after_model` runs once per model call, so every
  frontend call has to be answered before the routing edge evaluates, and `interrupt()` indexes its
  answers by call order.
- The state update carries `messages` only. No `jump_to`, because the `model`→`tools` edge already
  routes correctly. No `copilotkit` key, because that channel has no reducer and writing it would wipe
  `actions`, which the hook re-reads on resume.

</details>

### Open question: how should react/core handle an interrupt-borne tool call?

The agent side works within today's protocol surface. But the client side has no standard route at the moment (details below).

In the docs I added a **react "bridge"** one could use today to leverage the new opt-in interrupt flag. But this needs discussion, because it should also point in a direction that makes eventually this feature work out-of-the-box. 

<details><summary>What the react client does today</summary>


- **The default executor always runs a frontend handler, interrupt or not.** `runAgent` computes
  `newMessages` as an id-diff after the stream ends, regardless of how the run ended, so an
  interrupt-terminated run still reports the assistant message carrying the frontend `tool_calls`.
  `processAgentResult` finds no `ToolMessage` for the call, runs the handler, splices its own
  `ToolMessage`, and requests a follow-up run (`followUp` defaults to on). A bridge that acks instead of
  dispatching relies on this to execute fire-and-forget tools; a bridge that dispatches to
  `getTool().handler()` runs them twice.
- **A tool needing user input cannot be driven from the interrupt's `handler`.** Calling a handler
  directly never emits `onToolExecutionStart`, so `executingToolCallIds` never gains the id, the
  renderer never reaches `ToolCallStatus.Executing`, and a `useHumanInTheLoop` tool never receives a
  live `respond`. The promise never settles and the pause never ends. Resolving from the interrupt's own
  `render` works, so that is what the docs use.
- **AG-UI already models this case.** `Interrupt` carries `reason` and `tool_call_id`, `ɵInterruptState`
  derives `toolResults` from `reason: "tool_call"`, and `useInterrupt` appends the `ToolMessage` and
  resumes per interrupt id. None of it is reachable from LangGraph, because `ag_ui_langgraph` emits
  interrupts as a legacy `on_interrupt` CustomEvent carrying neither field.
- **The bridge in the docs is ~130 lines of protocol plumbing**: resolve from `render`, parse a value
  that arrives JSON-encoded, guard against Strict Mode resolving twice, and keep `enabled`/`render`
  identities stable so in-progress widget state survives.

</details>

<details><summary>Questions</summary>

The bridge I converged to feels confusing to me, because it's compromising between the `useInterrupt` and the `useFrontEndTool/useHumanInTheLoop` paths ([docs](https://docs.copilotkit.ai/teams/langgraph-typescript/human-in-the-loop#two-patterns-for-hitl-in-copilotkit)). 

I think this needs a bit of thinking from someone familiar with the react side of CopilotKit. I add here some observations and questions that arise around my bridge.

1. Should an interrupt-borne tool call go through the normal tool-execution lifecycle (emitting
   `onToolExecutionStart`/`End`, so renderers and `useHumanInTheLoop` behave as they do on the default
   path), or stay a separate track the bridge owns?
2. Is upstream `reason: "tool_call"` emission in `ag_ui_langgraph` the intended destination? If so, this
   flag's sentinel key and resume shape are transitional and should be documented as such.
4. Should react/core ship the bridge, so apps write no interrupt plumbing? If so, does the middleware
   keep classifying frontend calls from `copilotkit.actions`?
5. Should `processAgentResult` skip calls with a pending interrupt? It closes the double execution, but
   stops fire-and-forget tools that currently depend on it, so it needs a migration path.

</details>



<details><summary>Docs added</summary>

- `integrations/langgraph/frontend-tools` — new "awaiting frontend tool results in the same turn"
  section: agent setup, and a client bridge that claims only interrupts carrying the sentinel key,
  answers the batch once, and resolves from `render` so a call can ask the user something. Tools with no
  registered widget are acknowledged. This client bridge needs to be discussed in this PR.
- `integrations/langgraph/human-in-the-loop/interrupt-flow` — points readers there.

</details>

#### Testing

- `test_frontend_tool_interrupt.py` — end-to-end through real `create_agent` graphs 
- `test_copilotkit_lg_middleware.py` — unit coverage for batching, placeholder handling, etc

## Related PRs and Issues

- Closes #4920 
- ag-ui-protocol/ag-ui#1505
- ag-ui-protocol/ag-ui#2178


## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in mode that pauses agent execution while frontend tools run, then resumes the same turn with their results.
  - Supports batching multiple frontend tool calls and handling unanswered results.
  - Mixed frontend and backend tool calls are handled appropriately.

- **Documentation**
  - Added setup and usage guidance for frontend tool interrupts, client-side result handling, and resume behavior.
  - Updated interrupt-flow documentation with frontend tool support details.

- **Tests**
  - Added coverage for interrupt, resume, mixed-tool, sequential-turn, and default behavior scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->