### PR TITLE
docs: raise the stated Node version floor to 20

### DIFF
--- a/showcase/shell-docs/src/content/docs/cookbook/oracle-agent-spec-memory.mdx
+++ b/showcase/shell-docs/src/content/docs/cookbook/oracle-agent-spec-memory.mdx
@@ -49,7 +49,7 @@ the current conversation.
 
 ## Prerequisites
 
-- **Python 3.12** (required — `oracleagentmemory` ships a cp312 wheel), [`uv`](https://docs.astral.sh/uv/), Node.js 18+
+- **Python 3.12** (required — `oracleagentmemory` ships a cp312 wheel), [`uv`](https://docs.astral.sh/uv/), Node.js 20+
 - Docker (for the local Oracle AI Database) or your own Oracle AI Database
 - `OPENAI_API_KEY` (defaults use OpenAI via litellm)
 

--- a/showcase/shell-docs/src/content/docs/deploy/aws-lambda.mdx
+++ b/showcase/shell-docs/src/content/docs/deploy/aws-lambda.mdx
@@ -26,7 +26,7 @@ The handler code below is the same for both streaming paths; only the event shap
 
 ## Function URL with response streaming
 
-Response streaming requires three things: a Function URL with its invoke mode set to `RESPONSE_STREAM`, a handler wrapped in `awslambda.streamifyResponse`, and a Node.js managed runtime (Node.js 18 or later).
+Response streaming requires three things: a Function URL with its invoke mode set to `RESPONSE_STREAM`, a handler wrapped in `awslambda.streamifyResponse`, and a Node.js managed runtime of version 20 or later. AWS supports response streaming from Node.js 18, but `@copilotkit/runtime` requires Node.js 20.
 
 ### 1. The handler
 

--- a/showcase/shell-docs/src/content/snippets/langgraph-platform-deployment-tabs.mdx
+++ b/showcase/shell-docs/src/content/snippets/langgraph-platform-deployment-tabs.mdx
@@ -24,7 +24,7 @@ import { Tab } from "../components/react/tabs";
     ```
 
     ```bash
-    # For TypeScript with Node 18 or above
+    # For TypeScript with Node 20 or above
     npx @langchain/langgraph-cli dev --host localhost --port 8000
     ```
 


### PR DESCRIPTION
## What does this PR do?

Three documentation pages told readers Node 18 was enough. Node 18 reached end of life on 2025-04-30, and #7108 raised every published package to `engines.node: ">=20"`, so the guidance was wrong on both counts.

| File | Was | Now |
| --- | --- | --- |
| `docs/cookbook/oracle-agent-spec-memory.mdx:52` | `Node.js 18+` | `Node.js 20+` |
| `snippets/langgraph-platform-deployment-tabs.mdx:27` | `# For TypeScript with Node 18 or above` | `# ... Node 20 or above` |
| `docs/deploy/aws-lambda.mdx:29` | "a Node.js managed runtime (Node.js 18 or later)" | states the floor `@copilotkit/runtime` needs, and keeps the AWS fact |

The AWS Lambda page is the one judgment call. Response streaming genuinely works on Node 18 as far as AWS is concerned, so the page was not wrong about AWS — but it was steering CopilotKit users at a floor the runtime no longer supports, while its own examples already deploy `nodejs22.x`. The new wording keeps both facts:

> ...and a Node.js managed runtime of version 20 or later. AWS supports response streaming from Node.js 18, but `@copilotkit/runtime` requires Node.js 20.

## Testing

This is a prose-only change to existing MDX. No components, props, or code samples were touched, so there is nothing to execute. The claim that needs evidence is the **completeness of the sweep**, which I checked two ways against `origin/main` at `9bf9d4cd3f`.

**1. Version-claim regex across all of `shell-docs/src/content`:**

```
$ grep -rn -iE "node(\.js)?[[:space:]]*(v)?1[0-9]" showcase/shell-docs/src/content/
showcase/shell-docs/src/content/docs/deploy/aws-lambda.mdx:29: ...AWS supports response streaming from Node.js 18, but `@copilotkit/runtime` requires Node.js 20.
```

One hit, and it is the deliberate AWS clause above.

**2. A different technique, in case the regex shape was the blind spot** — every line containing `node`, filtered to those carrying a major between 14 and 19, with identifier noise (`node_modules`, `NodeNext`, `chat_node`, `ReactNode`, …) removed:

```
$ grep -rn -i "node" showcase/shell-docs/src/content/ | grep -E "1[4-9]" | grep -viE "node_modules|\.node|nodeType|NodeJS\.|nodes|NodeNext"
```

Same single hit. Every other Node version claim in the docs already reads 20+, 20.6+, or 22+.

**3. Format check scope.** The `format` job's file list covers `*.md` but not `*.mdx`, so a docs-only change hands it an empty list and the step exits 0 with "No formattable files changed in this PR". Nothing to pre-format here.

## Related

Follows #7108 (the `engines` floor) and #7089 (pino 10), and closes the documentation item noted in #7107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Oracle Agent Memory cookbook prerequisites to require Node.js 20 or later.
  - Clarified AWS Lambda streaming requirements: the runtime requires Node.js 20+, while AWS response streaming is supported from Node.js 18.
  - Updated LangGraph deployment guidance to recommend Node.js 20 or later for local TypeScript deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->